### PR TITLE
Optimise image and comment presentation

### DIFF
--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -82,6 +82,12 @@ class Message(object):
             if isimage:
                 message.append('<img class="file" src="%s">' % url)
 
+        if self._message.get('subtype', None) == 'file_comment':
+            comment = self._message['comment']
+            comment_text = comment['comment']
+            #message.append(self._render_text(comment_text))
+            message.append('<br /> %s' % comment_text)
+
         if not message[0].strip():
             message = message[1:]
         return "<br />".join(message).strip()

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -67,6 +67,21 @@ class Message(object):
                 text = self._render_text(att["text"].strip())
                 message.append(text)
 
+        if self._message.get('subtype', None) == 'file_share':
+            thefile = self._message['file']
+            minetype = thefile['mimetype']
+            if minetype.split('/')[0] == 'image':
+                isimage = True
+            else:
+                isimage = False
+            url = thefile['url_private']
+            url_download = thefile['url_private_download']
+            
+            message.append('<a href="%s">Download File</a>' % url_download)
+
+            if isimage:
+                message.append('<img class="file" src="%s">' % url)
+
         if not message[0].strip():
             message = message[1:]
         return "<br />".join(message).strip()
@@ -180,7 +195,7 @@ class Message(object):
 
     def _sub_channel_ref(self, matchobj):
         channel_id = matchobj.group(0)[2:-1]
-        channel_name = self.__CHANNEL_DATA[channel_id]["name"]
+        channel_name = self.__CHANNEL_DATA.get(channel_id, {}).get("name", 'NotExist')
         return "*#{}*".format(channel_name)
 
     def __em_strong(self, matchobj, format="em"):

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -49,7 +49,7 @@ body {
     padding-left: 25vw;
 }
 
-.messages img {
+.messages img.headshot {
     background-color: rgb(248, 244, 240);
     width: 36px;
     height: 36px;
@@ -58,6 +58,14 @@ body {
     vertical-align: top;
     margin-right: 0.65em;
     float: left;
+}
+
+.messages img.file {
+	margin-left: auto;
+	margin-right: auto;
+	width: 80%;
+    display: block;
+    vertical-align: top;
 }
 
 .messages .time {

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -27,7 +27,7 @@
 <div class="messages" id="fluid">
     {% for message in messages %}
     <div>
-        <img src="{{ message.img }}"/>
+        <img class="headshot" src="{{ message.img }}"/>
         <div class="message">
             <div class="username">{{ message.username }}</div>
             <div class="time">{{ message.time }}</div>


### PR DESCRIPTION
Sample:

<img width="628" alt="screen shot 2016-04-10 at 7 02 10 pm" src="https://cloud.githubusercontent.com/assets/1227160/14409844/7523a0c0-ff51-11e5-9a4a-a1175d7c6240.png">

<img width="335" alt="screen shot 2016-04-10 at 7 20 38 pm" src="https://cloud.githubusercontent.com/assets/1227160/14409845/762d1938-ff51-11e5-9839-a205271850c4.png">

Note, you don't have to login corresponding Slack team because the file URLs come with a token.
