### PR TITLE
fixed os-specific failure to correctly sort messages by date

### DIFF
--- a/slackviewer/archive.py
+++ b/slackviewer/archive.py
@@ -18,7 +18,7 @@ def compile_channels(path, user_data, channel_data):
     for channel in channels:
         channel_dir_path = os.path.join(path, channel)
         messages = []
-        for day in os.listdir(channel_dir_path):
+        for day in sorted(os.listdir(channel_dir_path)):
             with open(os.path.join(channel_dir_path, day)) as f:
                 day_messages = json.load(f)
                 messages.extend([Message(user_data, channel_data, d) for d in


### PR DESCRIPTION
In Linux, messages in a channel are not properly sorted by date as noted in #23.  This bug is OS-specific because of the OS-dependent behavior of `os.listdir()`.  Using sorted(os.listdir()) solves this issue.