### PR TITLE
Update main.py to remove Unicode issues

### DIFF
--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -45,7 +45,7 @@ def configure_app(app, archive, debug):
               type=click.INT, help="Host port to serve your content on")
 @click.option("-z", "--archive", type=click.Path(), required=True,
               default=envvar('SEV_ARCHIVE', ''),
-              help="Path to your Slack export archive (.zip file or directory)”)
+              help="Path to your Slack export archive (.zip file or directory)")
 @click.option('-I', '--ip', default=envvar('SEV_IP', 'localhost'),
               type=click.STRING, help="Host IP to serve your content on")
 @click.option('--no-browser', is_flag=True,


### PR DESCRIPTION
Python 2.7 on macOS 10.12.5 was showing error:
>SyntaxError: Non-ASCII character '\xe2' in file /Library/Python/2.7/site-packages/slackviewer/main.py on line 48, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

I fixed the issue by editing this quotation mark.