### PR TITLE
Added trailing "/" to channel routes

### DIFF
--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -8,7 +8,7 @@ app = flask.Flask(
 )
 
 
-@app.route("/channel/<name>")
+@app.route("/channel/<name>/")
 def channel_name(name):
     messages = flask._app_ctx_stack.channels[name]
     channels = list(flask._app_ctx_stack.channels.keys())


### PR DESCRIPTION
When trying to generate static html via [slack2html](https://github.com/hfaran/slack2html), was getting 'MimetypeMismatchWarning' errors for channels due to routes not being recognised as html.  Similar behaviour [has been seen before with Frozen-Flask](https://www.reddit.com/r/flask/comments/335cyi/a_problem_with_frozenflask/). Placing trailing slash in channel routes fixes the issue.