### PR TITLE
Add all channels, groups and dms & Add styling changes

### DIFF
--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -21,6 +21,7 @@ def channel_name(name):
                                  groups=sorted(groups),
                                  dm_users=sorted(dm_users))
 
+
 @app.route("/group/<name>/")
 def group_name(name):
     messages = flask._app_ctx_stack.groups[name]
@@ -33,6 +34,7 @@ def group_name(name):
                                  channels=sorted(channels),
                                  groups=sorted(groups),
                                  dm_users=sorted(dm_users))
+
 
 @app.route("/dm/<id>/")
 def dm_id(id):

--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -14,12 +14,14 @@ def channel_name(name):
     channels = list(flask._app_ctx_stack.channels.keys())
     groups = list(flask._app_ctx_stack.groups.keys())
     dm_users = list(flask._app_ctx_stack.dm_users)
+    mpim_users = list(flask._app_ctx_stack.mpim_users)
 
     return flask.render_template("viewer.html", messages=messages,
                                  name=name.format(name=name),
                                  channels=sorted(channels),
                                  groups=sorted(groups),
-                                 dm_users=sorted(dm_users))
+                                 dm_users=sorted(dm_users),
+                                 mpim_users=sorted(mpim_users))
 
 
 @app.route("/group/<name>/")
@@ -28,12 +30,14 @@ def group_name(name):
     channels = list(flask._app_ctx_stack.channels.keys())
     groups = list(flask._app_ctx_stack.groups.keys())
     dm_users = list(flask._app_ctx_stack.dm_users)
+    mpim_users = list(flask._app_ctx_stack.mpim_users)
 
     return flask.render_template("viewer.html", messages=messages,
                                  name=name.format(name=name),
                                  channels=sorted(channels),
                                  groups=sorted(groups),
-                                 dm_users=sorted(dm_users))
+                                 dm_users=sorted(dm_users),
+                                 mpim_users=sorted(mpim_users))
 
 
 @app.route("/dm/<id>/")
@@ -42,12 +46,30 @@ def dm_id(id):
     channels = list(flask._app_ctx_stack.channels.keys())
     groups = list(flask._app_ctx_stack.groups.keys())
     dm_users = list(flask._app_ctx_stack.dm_users)
+    mpim_users = list(flask._app_ctx_stack.mpim_users)
 
     return flask.render_template("viewer.html", messages=messages,
                                  id=id.format(id=id),
                                  channels=sorted(channels),
                                  groups=sorted(groups),
-                                 dm_users=sorted(dm_users))
+                                 dm_users=sorted(dm_users),
+                                 mpim_users=sorted(mpim_users))
+
+
+@app.route("/mpim/<name>/")
+def mpim_name(name):
+    messages = flask._app_ctx_stack.mpims[name]
+    channels = list(flask._app_ctx_stack.channels.keys())
+    groups = list(flask._app_ctx_stack.groups.keys())
+    dm_users = list(flask._app_ctx_stack.dm_users)
+    mpim_users = list(flask._app_ctx_stack.mpim_users)
+
+    return flask.render_template("viewer.html", messages=messages,
+                                 name=name.format(name=name),
+                                 channels=sorted(channels),
+                                 groups=sorted(groups),
+                                 dm_users=sorted(dm_users),
+                                 mpim_users=sorted(mpim_users))
 
 
 @app.route("/")

--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -13,24 +13,26 @@ def channel_name(name):
     messages = flask._app_ctx_stack.channels[name]
     channels = list(flask._app_ctx_stack.channels.keys())
     groups = list(flask._app_ctx_stack.groups.keys())
-    dms = list(flask._app_ctx_stack.dms.keys())
+    dm_users = list(flask._app_ctx_stack.dm_users)
+
     return flask.render_template("viewer.html", messages=messages,
                                  name=name.format(name=name),
                                  channels=sorted(channels),
                                  groups=sorted(groups),
-                                 dms=sorted(dms))
+                                 dm_users=sorted(dm_users))
 
 @app.route("/group/<name>/")
 def group_name(name):
     messages = flask._app_ctx_stack.groups[name]
     channels = list(flask._app_ctx_stack.channels.keys())
     groups = list(flask._app_ctx_stack.groups.keys())
-    dms = list(flask._app_ctx_stack.dms.keys())
+    dm_users = list(flask._app_ctx_stack.dm_users)
+
     return flask.render_template("viewer.html", messages=messages,
                                  name=name.format(name=name),
                                  channels=sorted(channels),
                                  groups=sorted(groups),
-                                 dms=sorted(dms))
+                                 dm_users=sorted(dm_users))
 
 @app.route("/dm/<id>/")
 def dm_id(id):

--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -12,9 +12,38 @@ app = flask.Flask(
 def channel_name(name):
     messages = flask._app_ctx_stack.channels[name]
     channels = list(flask._app_ctx_stack.channels.keys())
+    groups = list(flask._app_ctx_stack.groups.keys())
+    dms = list(flask._app_ctx_stack.dms.keys())
     return flask.render_template("viewer.html", messages=messages,
                                  name=name.format(name=name),
-                                 channels=sorted(channels))
+                                 channels=sorted(channels),
+                                 groups=sorted(groups),
+                                 dms=sorted(dms))
+
+@app.route("/group/<name>/")
+def group_name(name):
+    messages = flask._app_ctx_stack.groups[name]
+    channels = list(flask._app_ctx_stack.channels.keys())
+    groups = list(flask._app_ctx_stack.groups.keys())
+    dms = list(flask._app_ctx_stack.dms.keys())
+    return flask.render_template("viewer.html", messages=messages,
+                                 name=name.format(name=name),
+                                 channels=sorted(channels),
+                                 groups=sorted(groups),
+                                 dms=sorted(dms))
+
+@app.route("/dm/<id>/")
+def dm_id(id):
+    messages = flask._app_ctx_stack.dms[id]
+    channels = list(flask._app_ctx_stack.channels.keys())
+    groups = list(flask._app_ctx_stack.groups.keys())
+    dm_users = list(flask._app_ctx_stack.dm_users)
+
+    return flask.render_template("viewer.html", messages=messages,
+                                 id=id.format(id=id),
+                                 channels=sorted(channels),
+                                 groups=sorted(groups),
+                                 dm_users=sorted(dm_users))
 
 
 @app.route("/")

--- a/slackviewer/archive.py
+++ b/slackviewer/archive.py
@@ -86,7 +86,7 @@ def compile_dm_users(path, user_data, dm_data, empty_dms):
             user2 = user_data[dm["members"][1]]
             dm_user = {"id": dm["id"], "users": [user1, user2]}
             all_dms_users.append(dm_user)
-    print(all_dms_users[0])
+
     return all_dms_users
 
 # f is the file
@@ -173,7 +173,6 @@ def remove_empty_dirs(path):
 
     files = os.listdir(path)
     if len(files) == 0:
-        # print "Removing empty dir: ", path
         empty_dir_names.append(path[-9:])
         os.rmdir(path)
 

--- a/slackviewer/archive.py
+++ b/slackviewer/archive.py
@@ -6,14 +6,18 @@ import glob
 
 from slackviewer.message import Message
 
+
 def get_channel_list(path):
     return [c["name"] for c in get_channels(path).values()]
+
 
 def get_group_list(path):
     return [c["name"] for c in get_groups(path).values()]
 
+
 def get_dm_list(path):
     return [c["id"] for c in get_dms(path).values()]
+
 
 def get_dm_members_list(path):
     return [c for c in get_dms(path).values()]
@@ -36,6 +40,7 @@ def compile_channels(path, user_data, channel_data):
         chats[channel] = messages
     return chats
 
+
 def compile_groups(path, user_data, group_data):
     groups = get_group_list(path)
     chats = {}
@@ -52,6 +57,7 @@ def compile_groups(path, user_data, group_data):
                                  day_messages])
         chats[group] = messages
     return chats
+
 
 def compile_dms(path, user_data, dm_data):
     dms = get_dm_list(path)
@@ -70,31 +76,38 @@ def compile_dms(path, user_data, dm_data):
         chats[dm] = messages
     return chats
 
-def compile_dm_users(path, user_data, dm_data):
+
+def compile_dm_users(path, user_data, dm_data, empty_dms):
     dms = get_dm_members_list(path)
     all_dms_users = []
     for dm in dms:
-        user1 = user_data[dm["members"][0]]
-        user2 = user_data[dm["members"][1]]
-        dm_user = {"id": dm["id"], "users": [user1, user2]}
-        all_dms_users.append(dm_user)
+        if dm["id"] not in empty_dms:
+            user1 = user_data[dm["members"][0]]
+            user2 = user_data[dm["members"][1]]
+            dm_user = {"id": dm["id"], "users": [user1, user2]}
+            all_dms_users.append(dm_user)
     print(all_dms_users[0])
     return all_dms_users
 
 # f is the file
 # u is each object in the parent array
 # return statement creates array of objects with their id mapped to the object
+
+
 def get_users(path):
     with open(os.path.join(path, "users.json")) as f:
         return {u["id"]: u for u in json.load(f)}
+
 
 def get_channels(path):
     with open(os.path.join(path, "channels.json")) as f:
         return {u["id"]: u for u in json.load(f)}
 
+
 def get_groups(path):
     with open(os.path.join(path, "groups.json")) as f:
         return {u["id"]: u for u in json.load(f)}
+
 
 def get_dms(path):
     with open(os.path.join(path, "dms.json")) as f:
@@ -130,7 +143,8 @@ def extract_archive(filepath):
         # Add additional file with archive info
         archive_info = {
             "sha1": archive_sha,
-            "filename": os.path.split(filepath)[1]
+            "filename": os.path.split(filepath)[1],
+            "empty_dms": remove_empty_dirs(extracted_path)
         }
         with open(
             os.path.join(
@@ -141,3 +155,32 @@ def extract_archive(filepath):
             json.dump(archive_info, f)
 
     return extracted_path
+
+
+empty_dir_names = []
+
+
+def remove_empty_dirs(path):
+    if not os.path.isdir(path):
+        return
+
+    files = os.listdir(path)
+    if len(files):
+        for f in files:
+            fullpath = os.path.join(path, f)
+            if os.path.isdir(fullpath):
+                remove_empty_dirs(fullpath)
+
+    files = os.listdir(path)
+    if len(files) == 0:
+        # print "Removing empty dir: ", path
+        empty_dir_names.append(path[-9:])
+        os.rmdir(path)
+
+    return empty_dir_names
+
+
+def get_empty_dm_names(path):
+    info = os.path.join(path, ".slackviewer_archive_info.json")
+    with open(info) as i:
+        return json.load(i)["empty_dms"]

--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -7,6 +7,7 @@ import flask
 from slackviewer.app import app
 from slackviewer.archive import \
     extract_archive, \
+    get_empty_dm_names, \
     get_users, \
     get_channels, \
     get_groups, \
@@ -38,6 +39,8 @@ def configure_app(app, archive, debug):
 
     path = extract_archive(archive)
 
+    empty_dms = get_empty_dm_names(path)
+
     user_data = get_users(path)
     channel_data = get_channels(path)
     group_data = get_groups(path)
@@ -46,7 +49,7 @@ def configure_app(app, archive, debug):
     channels = compile_channels(path, user_data, channel_data)
     groups = compile_groups(path, user_data, group_data)
     dms = compile_dms(path, user_data, dm_data)
-    dm_users = compile_dm_users(path, user_data, dm_data)
+    dm_users = compile_dm_users(path, user_data, dm_data, empty_dms)
 
     top = flask._app_ctx_stack
     top.channels = channels

--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -12,10 +12,13 @@ from slackviewer.archive import \
     get_channels, \
     get_groups, \
     get_dms, \
+    get_mpims, \
     compile_channels, \
     compile_groups, \
     compile_dms, \
-    compile_dm_users
+    compile_dm_users, \
+    compile_mpims, \
+    compile_mpim_users
 
 
 def envvar(name, default):
@@ -45,17 +48,22 @@ def configure_app(app, archive, debug):
     channel_data = get_channels(path)
     group_data = get_groups(path)
     dm_data = get_dms(path)
+    mpim_data = get_mpims(path)
 
     channels = compile_channels(path, user_data, channel_data)
     groups = compile_groups(path, user_data, group_data)
     dms = compile_dms(path, user_data, dm_data)
     dm_users = compile_dm_users(path, user_data, dm_data, empty_dms)
+    mpims = compile_mpims(path, user_data, dm_data)
+    mpim_users = compile_mpim_users(path, user_data, mpim_data)
 
     top = flask._app_ctx_stack
     top.channels = channels
     top.groups = groups
     top.dms = dms
     top.dm_users = dm_users
+    top.mpims = mpims
+    top.mpim_users = mpim_users
 
 
 @click.command()

--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -9,7 +9,12 @@ from slackviewer.archive import \
     extract_archive, \
     get_users, \
     get_channels, \
-    compile_channels
+    get_groups, \
+    get_dms, \
+    compile_channels, \
+    compile_groups, \
+    compile_dms, \
+    compile_dm_users
 
 
 def envvar(name, default):
@@ -32,12 +37,22 @@ def configure_app(app, archive, debug):
     app.config["PROPAGATE_EXCEPTIONS"] = True
 
     path = extract_archive(archive)
+
     user_data = get_users(path)
     channel_data = get_channels(path)
+    group_data = get_groups(path)
+    dm_data = get_dms(path)
+
     channels = compile_channels(path, user_data, channel_data)
+    groups = compile_groups(path, user_data, group_data)
+    dms = compile_dms(path, user_data, dm_data)
+    dm_users = compile_dm_users(path, user_data, dm_data)
 
     top = flask._app_ctx_stack
     top.channels = channels
+    top.groups = groups
+    top.dms = dms
+    top.dm_users = dm_users
 
 
 @click.command()

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -1,52 +1,49 @@
+@import url('https://fonts.googleapis.com/css?family=Lato:400,900');
+
 * {
-    font-family: sans-serif;
+    font-family: 'Lato', sans-serif;
 }
 
 body {
-    text-align: center;
-    padding: 1em;
+    padding: 0;
+    margin: 0;
+    height: 100vh;
+    overflow: hidden;
 }
 
-#fixed {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-
-    padding-left: 2vw;
-    padding-right: 2vw;
-    padding-bottom: 2vw;
-
-    text-align: left;
-    background-color: #4D394B;
-    z-index: 10;
-    overflow-y: scroll;
-    overflow-x: auto;
+#sidebar {
+  display: inline-block;
+  width: 220px;
+  color: white;
+  text-align: left;
+  background-color: #4D394B;
+  z-index: 10;
+  overflow-y: scroll;
+  overflow-x: auto;
+  height: 100vh;
 }
 
-#fixed a {
+#sidebar a {
     color: white;
 }
 
-#fixed h3 {
-    color: white;
-}
-
-#fluid {
-    position: relative;
-    z-index: 1;
+#sidebar h3 {
+  margin: 20px 20px;
+  color: white;
+  font-weight: 900;
 }
 
 .messages {
-    width: 100%;
-    max-width: 70vw;
+    width: calc(100vw - 244px);
+    height: 100vh;
     text-align: left;
     display: inline-block;
-    /* For some reason, this pads from the left of the screen
-    as opposed to the right of the #fixed div, so we have a decent-ish 25vw
-    padding to cover most screens
-    XXX Still a hack though */
-    padding-left: 25vw;
+    padding-left: 20px;
+    overflow-y: scroll;
+}
+
+.messages .message-container:first-child {
+  margin-top: 20px;
 }
 
 .messages img {
@@ -83,19 +80,62 @@ body {
     line-height: 1.5;
 }
 
-#channel-list {
+.list {
     margin: 0;
     padding: 0;
     list-style-type: none;
 }
 
-#channel-list .active {
+.list .channel {
+    padding: 4px 20px;
+}
+
+.list .channel a {
+  width: 100%
+  padding: 10px 20px;
+}
+
+.list .channel.active {
     background-color: #4C9689;
 }
 
-#channel-list a:hover {
+.list .channel.active:hover {
+    background-color: #4C9689;
+}
+
+.list .channel:hover {
     text-decoration: none;
     background: #3E313C;
+}
+
+.list .channel a:hover {
+    text-decoration: none;
+}
+
+.list .group {
+    padding: 4px 20px;
+}
+
+.list .group a {
+  width: 100%
+  padding: 10px 20px;
+}
+
+.list .group.active {
+    background-color: #4C9689;
+}
+
+.list .group.active:hover {
+    background-color: #4C9689;
+}
+
+.list .group:hover {
+    text-decoration: none;
+    background: #3E313C;
+}
+
+.list .group a:hover {
+    text-decoration: none;
 }
 
 a:link,
@@ -109,4 +149,3 @@ a:hover {
     color: #439fe0;
     text-decoration: underline;
 }
-

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -13,7 +13,7 @@ body {
 
 #sidebar {
   display: inline-block;
-  width: 250px;
+  width: 280px;
   color: white;
   text-align: left;
   background-color: #4D394B;
@@ -21,6 +21,7 @@ body {
   overflow-y: scroll;
   overflow-x: auto;
   height: 100vh;
+  user-select: none;
 }
 
 #sidebar a {
@@ -34,8 +35,26 @@ body {
   font-weight: 900;
 }
 
+#sidebar h3:hover {
+  cursor: pointer;
+}
+
+#sidebar h3::after {
+  content: '❯ ';
+  display: inline-block;
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+  margin-left: 15px;
+}
+
+#sidebar h3.arrow::after {
+  margin-left: 10px;
+  -webkit-transform: none;
+  transform: none;
+}
+
 .messages {
-    width: calc(100vw - 274px);
+    width: calc(100vw - 304px);
     height: 100vh;
     text-align: left;
     display: inline-block;
@@ -87,81 +106,29 @@ body {
     list-style-type: none;
 }
 
-.list .channel {
+.list li {
     padding: 4px 20px;
 }
 
-.list .channel a {
+.list li a {
   width: 100%
   padding: 10px 20px;
 }
 
-.list .channel.active {
+.list li.active {
     background-color: #4C9689;
 }
 
-.list .channel.active:hover {
+.list li.active:hover {
     background-color: #4C9689;
 }
 
-.list .channel:hover {
+.list li:hover {
     text-decoration: none;
     background: #3E313C;
 }
 
-.list .channel a:hover {
-    text-decoration: none;
-}
-
-.list .group {
-    padding: 4px 20px;
-}
-
-.list .group a {
-  width: 100%
-  padding: 10px 20px;
-}
-
-.list .group.active {
-    background-color: #4C9689;
-}
-
-.list .group.active:hover {
-    background-color: #4C9689;
-}
-
-.list .group:hover {
-    text-decoration: none;
-    background: #3E313C;
-}
-
-.list .group a:hover {
-    text-decoration: none;
-}
-
-.list .dm {
-    padding: 4px 20px;
-}
-
-.list .dm a {
-  width: 100%
-  padding: 10px 20px;
-}
-
-.list .dm.active {
-    background-color: #4C9689;
-}
-
-.list .dm.active:hover {
-    background-color: #4C9689;
-}
-
-.list .dm:hover {
-    text-decoration: none;
-    background: #3E313C;
-}
-
-.list .dm a:hover {
+.list li a:hover {
     text-decoration: none;
 }
 
@@ -175,4 +142,8 @@ a:active {
 a:hover {
     color: #439fe0;
     text-decoration: underline;
+}
+
+.close {
+  display: none;
 }

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -13,7 +13,7 @@ body {
 
 #sidebar {
   display: inline-block;
-  width: 220px;
+  width: 250px;
   color: white;
   text-align: left;
   background-color: #4D394B;
@@ -25,6 +25,7 @@ body {
 
 #sidebar a {
     color: white;
+    font-size: 14px;
 }
 
 #sidebar h3 {
@@ -34,7 +35,7 @@ body {
 }
 
 .messages {
-    width: calc(100vw - 244px);
+    width: calc(100vw - 274px);
     height: 100vh;
     text-align: left;
     display: inline-block;

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -138,6 +138,32 @@ body {
     text-decoration: none;
 }
 
+.list .dm {
+    padding: 4px 20px;
+}
+
+.list .dm a {
+  width: 100%
+  padding: 10px 20px;
+}
+
+.list .dm.active {
+    background-color: #4C9689;
+}
+
+.list .dm.active:hover {
+    background-color: #4C9689;
+}
+
+.list .dm:hover {
+    text-decoration: none;
+    background: #3E313C;
+}
+
+.list .dm a:hover {
+    text-decoration: none;
+}
+
 a:link,
 a:visited,
 a:active {

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -11,7 +11,7 @@
     <h3>Public Channels</h3>
     <ul class="list" id="channel-list">
         {% for channel in channels %}
-            <li class="channel {% if channel == name %}active{% endif %}">
+            <li class="channel{% if channel == name %} active{% endif %}">
                 <a href="{{ url_for('channel_name', name=channel) }}">
                     # {{ channel }}
                 </a>
@@ -21,9 +21,19 @@
     <h3>Private Channels</h3>
     <ul class="list" id="group-list">
         {% for group in groups %}
-            <li class="group {% if group == name %}active{% endif %}">
+            <li class="group{% if group == name %} active{% endif %}">
                 <a href="{{ url_for('group_name', name=group) }}">
                     &#128274; {{ group }}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+    <h3>Direct Messages</h3>
+    <ul class="list" id="dms-list">
+        {% for dm in dm_users %}
+            <li class="dm{% if dm['id'] == id %} active{% endif %}">
+                <a href="{{ url_for('dm_id', id=dm['id']) }}">
+                    &#128100; {{ dm["users"][0].name }}, {{ dm["users"][1].name }}
                 </a>
             </li>
         {% endfor %}

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -2,26 +2,36 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>#{{ name }}</title>
+    <title>Slack Export - #{{ name }}</title>
     <link rel=stylesheet type=text/css
           href="{{ url_for('static', filename='viewer.css') }}">
 </head>
 <body>
-<div id="fixed">
-    <h3>Channels</h3>
-    <ul id="channel-list">
+<div id="sidebar">
+    <h3>Public Channels</h3>
+    <ul class="list" id="channel-list">
         {% for channel in channels %}
             <li class="channel {% if channel == name %}active{% endif %}">
                 <a href="{{ url_for('channel_name', name=channel) }}">
-                    #{{ channel }}
+                    # {{ channel }}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+    <h3>Private Channels</h3>
+    <ul class="list" id="group-list">
+        {% for group in groups %}
+            <li class="group {% if group == name %}active{% endif %}">
+                <a href="{{ url_for('group_name', name=group) }}">
+                    &#128274; {{ group }}
                 </a>
             </li>
         {% endfor %}
     </ul>
 </div>
-<div class="messages" id="fluid">
+<div class="messages">
     {% for message in messages %}
-        <div>
+        <div class="message-container">
           <div id="{{ message.id }}">
             <img src="{{ message.img }}"/>
             <div class="message">

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -57,11 +57,9 @@
 
 <script>
   var sidebar = document.querySelector('#sidebar');
-  sidebar.scrollTop = window.localStorage.getItem('scroll');
+  var selected = document.querySelector('.active');
+  sidebar.scrollTop = selected.offsetTop - 200;
 
-  sidebar.addEventListener('click', function() {
-    window.localStorage.setItem('scroll', sidebar.scrollTop);
-  });
 </script>
 </body>
 </html>

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -33,7 +33,7 @@
         {% for dm in dm_users %}
             <li class="dm{% if dm['id'] == id %} active{% endif %}">
                 <a href="{{ url_for('dm_id', id=dm['id']) }}">
-                    &#128100; {{ dm["users"][0].name }}, {{ dm["users"][1].name }}
+                    &#128100; {{ dm["users"][0].real_name }}, {{ dm["users"][1].real_name }}
                 </a>
             </li>
         {% endfor %}

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -33,7 +33,7 @@
         {% for dm in dm_users %}
             <li class="dm{% if dm['id'] == id %} active{% endif %}">
                 <a href="{{ url_for('dm_id', id=dm['id']) }}">
-                    &#128100; {{ dm["users"][0].real_name }}, {{ dm["users"][1].real_name }}
+                    &#128100; {{ dm["users"][0].real_name if dm["users"][0].real_name else dm["users"][0].name }}, {{ dm["users"][1].real_name if dm["users"][1].real_name else dm["users"][1].name }}
                 </a>
             </li>
         {% endfor %}
@@ -54,5 +54,14 @@
         <br/>
     {% endfor %}
 </div>
+
+<script>
+  var sidebar = document.querySelector('#sidebar');
+  sidebar.scrollTop = window.localStorage.getItem('scroll');
+
+  sidebar.addEventListener('click', function() {
+    window.localStorage.setItem('scroll', sidebar.scrollTop);
+  });
+</script>
 </body>
 </html>

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <div id="sidebar">
-    <h3>Public Channels</h3>
+    <h3 id="channel-title">Public Channels</h3>
     <ul class="list" id="channel-list">
         {% for channel in channels %}
             <li class="channel{% if channel == name %} active{% endif %}">
@@ -18,7 +18,7 @@
             </li>
         {% endfor %}
     </ul>
-    <h3>Private Channels</h3>
+    <h3 id="group-title">Private Channels</h3>
     <ul class="list" id="group-list">
         {% for group in groups %}
             <li class="group{% if group == name %} active{% endif %}">
@@ -28,12 +28,25 @@
             </li>
         {% endfor %}
     </ul>
-    <h3>Direct Messages</h3>
+    <h3 id="dm-title">Direct Messages</h3>
     <ul class="list" id="dms-list">
         {% for dm in dm_users %}
             <li class="dm{% if dm['id'] == id %} active{% endif %}">
                 <a href="{{ url_for('dm_id', id=dm['id']) }}">
                     &#128100; {{ dm["users"][0].real_name if dm["users"][0].real_name else dm["users"][0].name }}, {{ dm["users"][1].real_name if dm["users"][1].real_name else dm["users"][1].name }}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+    <h3 id="mpim-title">Group Direct Messages</h3>
+    <ul class="list" id="mpims-list">
+        {% for mpim in mpim_users %}
+            <li class="mpim{% if mpim['name'] == name %} active{% endif %}">
+                <a href="{{ url_for('mpim_name', name=mpim['name']) }}">
+                    &#128101;
+                    {% for user in mpim["users"] %}
+                    {{ user.real_name if user.real_name else user.name }},
+                    {% endfor %}
                 </a>
             </li>
         {% endfor %}
@@ -56,10 +69,43 @@
 </div>
 
 <script>
+(function() {
   var sidebar = document.querySelector('#sidebar');
   var selected = document.querySelector('.active');
   sidebar.scrollTop = selected.offsetTop - 200;
 
+  // make dropdown from channel title
+  var channel_title = document.querySelector("#channel-title");
+  var channel_dropdown = document.querySelector("#channel-list");
+  channel_title.addEventListener('click', function() {
+    channel_title.classList.toggle('arrow');
+    channel_dropdown.classList.toggle('close');
+  });
+
+  // make dropdown from group title
+  var group_title = document.querySelector("#group-title");
+  var group_dropdown = document.querySelector("#group-list");
+  group_title.addEventListener('click', function() {
+    group_title.classList.toggle('arrow');
+    group_dropdown.classList.toggle('close');
+  });
+
+  // make dropdown from dm title
+  var dm_title = document.querySelector("#dm-title");
+  var dm_dropdown = document.querySelector("#dms-list");
+  dm_title.addEventListener('click', function() {
+    dm_title.classList.toggle('arrow');
+    dm_dropdown.classList.toggle('close');
+  });
+
+  // make dromdown from group dm title
+  var mpim_title = document.querySelector("#mpim-title");
+  var mpim_dropdown = document.querySelector("#mpims-list");
+  mpim_title.addEventListener('click', function() {
+    mpim_title.classList.toggle('arrow');
+    mpim_dropdown.classList.toggle('close');
+  });
+})()
 </script>
 </body>
 </html>


### PR DESCRIPTION
Changes in this PR:
 - allows the user to view all of the private groups, one-to-one direct messages, and multiple person direct messages. 
- styling changes were made for a more responsive and user friendly interface. It now has an appearance closer to slack
- dropdown menus for each type of message group. 
- when going to a different page the sidebar will scroll to the position of that element in the list. 
- for the one-to-one direct messages, the extractor will save the list of dm ids that do not exist in the archive. This can then be used upon relaunch to filter out unused dm ids.