### PR TITLE
Fix for Shared Workspace Users

### DIFF
--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -65,8 +65,12 @@ class Reader(object):
         for dm in dms:
             # checks if messages actually exsist
             if dm["id"] not in self._EMPTY_DMS:
-                dm_members = {"id": dm["id"], "users": [self.__USER_DATA[m] for m in dm["members"]]}
-                all_dms_users.append(dm_members)
+                # added try catch for users from shared workspaces not in current workspace
+                try:
+                    dm_members = {"id": dm["id"], "users": [self.__USER_DATA[m] for m in dm["members"]]}
+                    all_dms_users.append(dm_members)
+                except KeyError:
+                    dm_members = None   
 
         return all_dms_users
 


### PR DESCRIPTION
Issue: our project has shared workspaces (external company users on a separate workspace)
When loading the import it fails:
```
Traceback (most recent call last):
  File "C:\Python27\lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "C:\Python27\lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "C:\Python27\Scripts\slack-export-viewer.exe\__main__.py", line 9, in <module>
  File "C:\Python27\lib\site-packages\click\core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "C:\Python27\lib\site-packages\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "C:\Python27\lib\site-packages\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Python27\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "C:\Python27\lib\site-packages\slackviewer\main.py", line 50, in main
    configure_app(app, archive, debug)
  File "C:\Python27\lib\site-packages\slackviewer\main.py", line 25, in configure_app
    top.dm_users = reader.compile_dm_users()
  File "C:\Python27\lib\site-packages\slackviewer\reader.py", line 68, in compile_dm_users
    dm_members = {"id": dm["id"], "users": [self.__USER_DATA[m] for m in dm["members"]]}
KeyError: u'U9T4TV5CJ'
```

Fix: After some debugging I noticed this was one of those users. I added a try catch similar to #20 to fix this. Will look into fixing this better as I get more time.