### PR TITLE
User name rendering refactor

### DIFF
--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -4,6 +4,7 @@ import glob
 import io
 
 from slackviewer.message import Message
+from slackviewer.user import User
 
 class Reader(object):
     """
@@ -14,7 +15,7 @@ class Reader(object):
         self._PATH = PATH
         # TODO: Make sure this works
         with io.open(os.path.join(self._PATH, "users.json"), encoding="utf8") as f:
-            self.__USER_DATA = {u["id"]: u for u in json.load(f)}
+            self.__USER_DATA = {u["id"]: User(u) for u in json.load(f)}
 
 
     ##################

--- a/slackviewer/user.py
+++ b/slackviewer/user.py
@@ -1,0 +1,46 @@
+# User info wrapper object
+
+class User(object):
+    """
+    Wrapper object around an entry in users.json. Behaves like a read-only dictionary if
+    asked, but adds some useful logic to decouple the front end from the JSON structure.
+    """
+
+    _NAME_KEYS = ["display_name", "real_name"]
+    _DEFAULT_IMAGE_KEY = "image_512"
+
+    def __init__(self, raw_data):
+        self._raw = raw_data
+
+    def __getitem__(self, key):
+        return self._raw[key]
+
+    @property
+    def display_name(self):
+        """
+        Find the most appropriate display name for a user: look for a "display_name", then
+        a "real_name", and finally fall back to the always-present "name".
+        """
+        for k in self._NAME_KEYS:
+            if self._raw.get(k):
+                return self._raw[k]
+            if self._raw["profile"].get(k):
+                return self._raw["profile"][k]
+        return self._raw["name"]
+
+    @property
+    def email(self):
+        "Shortcut property for finding the e-mail address."
+        return self._raw["profile"]["email"]
+
+    def image_url(self, pixel_size=None):
+        """
+        Get the URL for the user icon in the desired pixel size, if it exists. If no
+        size is supplied, give the URL for the full-size image.
+        """
+        profile = self._raw["profile"]
+        if (pixel_size):
+            img_key = "image_%s" % pixel_size
+            if img_key in profile:
+                return profile[img_key]
+        return profile[self._DEFAULT_IMAGE_KEY]


### PR DESCRIPTION
A minor bug fix and a refactoring effort aimed at getting some of the user-related logic out of the Message object.

* adds a dictionary-like wrapper class for User, to hold logic about extracting information from the `users.json` record.
* fixes a latent bug with the matching of user-mention tags, which had an assumption built into their regex that is no longer valid
* adds a method to get a better approximation of the name that would be displayed in the Slack application