### PR TITLE
Rendering and CSS fixes for code blocks.

### DIFF
--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -145,27 +145,19 @@ class Message(object):
                 # We still have nice bold and italics formatting though
                 #  because we pre-process underscores into asterisks. :)
                 "code-friendly",
+                # This gives us <pre> and <code> tags for ```-fenced blocks
                 "fenced-code-blocks",
                 "pyshell"
             ]
         ).strip()
-        # markdown2 likes to wrap everything in <p> tags
-        if message.startswith("<p>") and message.endswith("</p>"):
-            message = message[3:-4]
 
         # Newlines to breaks
         # Special handling cases for lists
         message = message.replace("\n\n<ul>", "<ul>")
         message = message.replace("\n<li>", "<li>")
-        # Indiscriminately replace everything else
-        message = message.replace("\n", "<br />")
 
         # Introduce unicode emoji
         message = emoji.emojize(message, use_aliases=True)
-
-        # Adding <pre> tag for preformated code
-        message = re.sub(r"```(.*?)```", r'<pre style="background-color: #E6E5DF; white-space: pre-wrap;">\1</pre>',
-                         message)
 
         return message
 

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css?family=Lato:400,900');
 
-* {
+html {
     font-family: 'Lato', sans-serif;
 }
 
@@ -94,6 +94,15 @@ body {
     vertical-align: top;
     line-height: 1;
     width: calc(100% - 3em);
+}
+
+.message-container .msg p {
+    white-space: pre-wrap;
+}
+
+.message-container .msg pre {
+    background-color: #E6E5DF;
+    white-space: pre-wrap;
 }
 
 .messages .message .msg {


### PR DESCRIPTION
Removed two post-processing steps and added some CSS to make code blocks work again.

* the manual processing of triple-backtick blocks was a no-op, because that
  function is handled by the markdown2 "fenced-code-blocks" extra
* the manual removal of `<p></p>` tags was producing invalid HTML that was harder
  to format: deleted it
* the bulk substitution of newlines with `<br>` tags was replaced with a CSS rule
* CSS font-family rules were tweaked in order to allow the font-family rule for
  `<code>` in user-agent stylesheets to work correctly