### PR TITLE
Layout/rendering separation

### DIFF
--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -107,6 +107,10 @@ class Message(object):
     def id(self):
         return self.time
 
+    @property
+    def subtype(self):
+        return self._message.get("subtype")
+
     ###################
     # Private Methods #
     ###################

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -7,6 +7,11 @@ html {
 body {
     padding: 0;
     margin: 0;
+}
+
+#slack-archive-viewer {
+    padding: 0;
+    margin: 0;
     height: 100vh;
     overflow: hidden;
 }
@@ -62,11 +67,11 @@ body {
     overflow-y: scroll;
 }
 
-.messages .message-container:first-child {
+.message-container:first-child {
   margin-top: 20px;
 }
 
-.messages img {
+.message-container img {
     background-color: rgb(248, 244, 240);
     width: 36px;
     height: 36px;
@@ -77,19 +82,19 @@ body {
     float: left;
 }
 
-.messages .time {
+.message-container .time {
     display: inline-block;
     color: rgb(200, 200, 200);
     margin-left: 0.5em;
 }
 
-.messages .username {
+.message-container .username {
     display: inline-block;
     font-weight: 600;
     line-height: 1;
 }
 
-.messages .message {
+.message-container .message {
     display: inline-block;
     vertical-align: top;
     line-height: 1;
@@ -105,7 +110,7 @@ body {
     white-space: pre-wrap;
 }
 
-.messages .message .msg {
+.message-container .message .msg {
     line-height: 1.5;
 }
 

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -114,6 +114,10 @@ body {
     line-height: 1.5;
 }
 
+.channel_join .msg, .channel_topic .msg {
+    font-style: italic;
+}
+
 .list {
     margin: 0;
     padding: 0;

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -7,6 +7,7 @@
           href="{{ url_for('static', filename='viewer.css') }}">
 </head>
 <body>
+<div id="slack-archive-viewer">
 <div id="sidebar">
     <h3 id="channel-title">Public Channels</h3>
     <ul class="list" id="channel-list">
@@ -66,6 +67,7 @@
         </div>
         <br/>
     {% endfor %}
+</div>
 </div>
 
 <script>

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -55,7 +55,7 @@
     </div>
     <div class="messages">
         {% for message in messages %}
-            <div class="message-container">
+            <div class="message-container{%if message.subtype %} {{message.subtype}}{%endif%}">
             <div id="{{ message.id }}">
                 <img src="{{ message.img }}"/>
                 <div class="message">

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -8,66 +8,66 @@
 </head>
 <body>
 <div id="slack-archive-viewer">
-<div id="sidebar">
-    <h3 id="channel-title">Public Channels</h3>
-    <ul class="list" id="channel-list">
-        {% for channel in channels %}
-            <li class="channel{% if channel == name %} active{% endif %}">
-                <a href="{{ url_for('channel_name', name=channel) }}">
-                    # {{ channel }}
-                </a>
-            </li>
-        {% endfor %}
-    </ul>
-    <h3 id="group-title">Private Channels</h3>
-    <ul class="list" id="group-list">
-        {% for group in groups %}
-            <li class="group{% if group == name %} active{% endif %}">
-                <a href="{{ url_for('group_name', name=group) }}">
-                    &#128274; {{ group }}
-                </a>
-            </li>
-        {% endfor %}
-    </ul>
-    <h3 id="dm-title">Direct Messages</h3>
-    <ul class="list" id="dms-list">
-        {% for dm in dm_users %}
-            <li class="dm{% if dm['id'] == id %} active{% endif %}">
-                <a href="{{ url_for('dm_id', id=dm['id']) }}">
-                    &#128100; {{ dm["users"][0].real_name if dm["users"][0].real_name else dm["users"][0].name }}, {{ dm["users"][1].real_name if dm["users"][1].real_name else dm["users"][1].name }}
-                </a>
-            </li>
-        {% endfor %}
-    </ul>
-    <h3 id="mpim-title">Group Direct Messages</h3>
-    <ul class="list" id="mpims-list">
-        {% for mpim in mpim_users %}
-            <li class="mpim{% if mpim['name'] == name %} active{% endif %}">
-                <a href="{{ url_for('mpim_name', name=mpim['name']) }}">
-                    &#128101;
-                    {% for user in mpim["users"] %}
-                    {{ user.real_name if user.real_name else user.name }},
-                    {% endfor %}
-                </a>
-            </li>
-        {% endfor %}
-    </ul>
-</div>
-<div class="messages">
-    {% for message in messages %}
-        <div class="message-container">
-          <div id="{{ message.id }}">
-            <img src="{{ message.img }}"/>
-            <div class="message">
-                <div class="username">{{ message.username }}</div>
-                <a href="#{{ message.id}}"><div class="time">{{ message.time }}</div></a>
-                <div class="msg">{{ message.msg|safe }}</div>
+    <div id="sidebar">
+        <h3 id="channel-title">Public Channels</h3>
+        <ul class="list" id="channel-list">
+            {% for channel in channels %}
+                <li class="channel{% if channel == name %} active{% endif %}">
+                    <a href="{{ url_for('channel_name', name=channel) }}">
+                        # {{ channel }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+        <h3 id="group-title">Private Channels</h3>
+        <ul class="list" id="group-list">
+            {% for group in groups %}
+                <li class="group{% if group == name %} active{% endif %}">
+                    <a href="{{ url_for('group_name', name=group) }}">
+                        &#128274; {{ group }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+        <h3 id="dm-title">Direct Messages</h3>
+        <ul class="list" id="dms-list">
+            {% for dm in dm_users %}
+                <li class="dm{% if dm['id'] == id %} active{% endif %}">
+                    <a href="{{ url_for('dm_id', id=dm['id']) }}">
+                        &#128100; {{ dm["users"][0].real_name if dm["users"][0].real_name else dm["users"][0].name }}, {{ dm["users"][1].real_name if dm["users"][1].real_name else dm["users"][1].name }}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+        <h3 id="mpim-title">Group Direct Messages</h3>
+        <ul class="list" id="mpims-list">
+            {% for mpim in mpim_users %}
+                <li class="mpim{% if mpim['name'] == name %} active{% endif %}">
+                    <a href="{{ url_for('mpim_name', name=mpim['name']) }}">
+                        &#128101;
+                        {% for user in mpim["users"] %}
+                        {{ user.real_name if user.real_name else user.name }},
+                        {% endfor %}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+    <div class="messages">
+        {% for message in messages %}
+            <div class="message-container">
+            <div id="{{ message.id }}">
+                <img src="{{ message.img }}"/>
+                <div class="message">
+                    <div class="username">{{ message.username }}</div>
+                    <a href="#{{ message.id}}"><div class="time">{{ message.time }}</div></a>
+                    <div class="msg">{{ message.msg|safe }}</div>
+                </div>
             </div>
-          </div>
-        </div>
-        <br/>
-    {% endfor %}
-</div>
+            </div>
+            <br/>
+        {% endfor %}
+    </div>
 </div>
 
 <script>


### PR DESCRIPTION
Some template and CSS changes to separate the rules involved in the pseudo-frame layout from those involved in the rendering of individual messages.

* added a wrapper div to take most of the layout rules off of `body`
* changed selectors for rules inside the `messages` div to make them depend on `message-container` instead
* added rules to italicize channel-join and channel-topic messages
* reformatted the template to correct the indentation problem introduced by the wrapper-div commit (intentionally separated to make it easier to read).

Note: the most interesting changes are all bundled together in b70fc5c6b57ebd731f0d495b5eebaf7cb60ec480, which is probably easier to read (especially with respect to the changes to `viewer.html`) than the overall diff.