### PR TITLE
Updated and refactored message rendering

### DIFF
--- a/slackviewer/formatter.py
+++ b/slackviewer/formatter.py
@@ -1,0 +1,119 @@
+import logging
+import re
+
+import emoji
+import markdown2
+
+from slackviewer.user import User
+
+class SlackFormatter(object):
+    "This formats messages and provides access to workspace-wide data (user and channel metadata)."
+
+    # Class-level constants for precompilation of frequently-reused regular expressions
+    # URL detection relies on http://stackoverflow.com/a/1547940/1798683
+    _LINK_PAT = re.compile(r"<(https|http|mailto):[A-Za-z0-9_\.\-\/\?\,\=\#\:\@]+\|[^>]+>")
+    _MENTION_PAT = re.compile(r"<((?:#C|@[UB])\w+)(?:\|([A-Za-z0-9.-_]+))?>")
+    _HASHTAG_PAT = re.compile(r"(^| )#[A-Za-z][\w\.\-\_]+( |$)")
+
+    def __init__(self, USER_DATA, CHANNEL_DATA):
+        self.__USER_DATA = USER_DATA
+        self.__CHANNEL_DATA = CHANNEL_DATA
+
+    def find_user(self, message):
+        if message.get("user") == "USLACKBOT":
+            return User({"name":"slackbot"})
+        if message.get("subtype", "").startswith("bot_") and message["bot_id"] not in self.__USER_DATA:
+            bot_id = message["bot_id"]
+            logging.debug("bot addition for %s", bot_id)
+            if "bot_link" in message:
+                (bot_url, bot_name) = message["bot_link"].strip("<>").split("|", 1)
+            elif "username" in message:
+                bot_name = message["username"]
+                bot_url = None
+
+            self.__USER_DATA[bot_id] = User({
+                "user": bot_id,
+                "real_name": bot_name,
+                "bot_url": bot_url,
+                "is_bot": True,
+                "is_app_user": True
+            })
+        user_id = message.get("user") or message.get("bot_id")
+        if user_id in self.__USER_DATA:
+            return self.__USER_DATA.get(user_id)
+        logging.error("unable to find user in %s", message)
+
+    def render_text(self, message, process_markdown=True):
+        message = message.replace("<!channel>", "@channel")
+        message = self._slack_to_accepted_emoji(message)
+
+        # Handle mentions of users, channels and bots (e.g "<@U0BM1CGQY|calvinchanubc> has joined the channel")
+        message = self._MENTION_PAT.sub(self._sub_annotated_mention, message)
+        # Handle links
+        message = self._LINK_PAT.sub(self._sub_hyperlink, message)
+        # Handle hashtags (that are meant to be hashtags and not headings)
+        message = self._HASHTAG_PAT.sub(self._sub_hashtag, message)
+
+        # Introduce unicode emoji
+        message = emoji.emojize(message, use_aliases=True)
+
+        if process_markdown:
+            # Handle bold (convert * * to ** **)
+            message = re.sub(r'\*', "**", message)
+
+            message = markdown2.markdown(
+                message,
+                extras=[
+                    "cuddled-lists",
+                    # This gives us <pre> and <code> tags for ```-fenced blocks
+                    "fenced-code-blocks",
+                    "pyshell"
+                ]
+            ).strip()
+
+        # Special handling cases for lists
+        message = message.replace("\n\n<ul>", "<ul>")
+        message = message.replace("\n<li>", "<li>")
+
+        return message
+
+    def _slack_to_accepted_emoji(self, message):
+        # https://github.com/Ranks/emojione/issues/114
+        message = message.replace(":simple_smile:", ":slightly_smiling_face:")
+        return message
+
+    def _sub_annotated_mention(self, matchobj):
+        ref_id = matchobj.group(1)[1:]  # drop #/@ from the start, we don't care
+        annotation = matchobj.group(2)
+        if ref_id.startswith('C'):
+            mention_format = "<b>#{}</b>"
+            if not annotation:
+                channel = self.__CHANNEL_DATA.get(ref_id)
+                annotation = channel["name"] if channel else ref_id
+        else:
+            mention_format = "@{}"
+            if not annotation:
+                user = self.__USER_DATA.get(ref_id)
+                annotation = user.display_name if user else ref_id
+        return mention_format.format(annotation)
+
+    def _sub_hyperlink(self, matchobj):
+        compound = matchobj.group(0)[1:-1]
+        if len(compound.split("|")) == 2:
+            url, title = compound.split("|")
+        else:
+            url, title = compound, compound
+        result = "<a href=\"{url}\">{title}</a>".format(url=url, title=title)
+        return result
+
+    def _sub_hashtag(self, matchobj):
+        text = matchobj.group(0)
+
+        starting_space = " " if text[0] == " " else ""
+        ending_space = " " if text[-1] == " " else ""
+
+        return "{}<b>{}</b>{}".format(
+            starting_space,
+            text.strip(),
+            ending_space
+        )

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -248,14 +248,25 @@ class LinkAttachment(object):
         else: # FILE type
             thumb_key = "thumb_{}".format(size)
             logging.debug("thumb path" + thumb_key)
+            if thumb_key not in self._raw:
+                # let's try some fallback logic
+                thumb_key = "thumb_{}".format(self._raw.get("filetype"))
+                if thumb_key not in self._raw:
+                    # pick the first one that shows up in the iterator
+                    candidates = [k for k in self._raw.keys()
+                        if k.startswith("thumb_") and not k.endswith(("_w","_h"))]
+                    if candidates:
+                        thumb_key = candidates[0]
+                        logging.info("Fell back to thumbnail key %s for [%s]",
+                            thumb_key, self._raw.get("title"))
             if thumb_key in self._raw:
                 return {
                     "src": self._raw[thumb_key],
-                    "width": self._raw.get(thumb_key + "_w", size),
-                    "height": self._raw.get(thumb_key + "_h", size),
+                    "width": self._raw.get(thumb_key + "_w"),
+                    "height": self._raw.get(thumb_key + "_h"),
                 }
             else:
-                pass # thumb_pdf or possibly thumb_${filetype}?
+                logging.info("No thumbnail found for [%s]", self._raw.get("title"))
 
     @property
     def is_image(self):

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -159,7 +159,12 @@ class LinkAttachment(object):
 
     @property
     def fields(self):
-        "Only present on attachments, not files--this abstraction isn't 100% awesome.'"
+        """
+        Fetch the "fields" list, and process the text within each field, including markdown
+        processing if the message indicates that the fields contain markdown.
+
+        Only present on attachments, not files--this abstraction isn't 100% awesome.'
+        """
         process_markdown = ("fields" in self._raw.get("mrkdwn_in", []))
         fields = self._raw.get("fields", [])
         if fields:

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -2,19 +2,14 @@ from __future__ import unicode_literals
 
 import datetime
 import logging
-import re
-
-import emoji
-import markdown2
-from slackviewer.user import User
 
 
 class Message(object):
 
     _DEFAULT_USER_ICON_SIZE = 72
 
-    def __init__(self, USER_DATA, CHANNEL_DATA, message):
-        self._formatter = SlackFormatter(USER_DATA, CHANNEL_DATA)
+    def __init__(self, formatter, message):
+        self._formatter = formatter
         self._message = message
 
     ##############
@@ -94,119 +89,6 @@ class Message(object):
     @property
     def subtype(self):
         return self._message.get("subtype")
-
-
-class SlackFormatter(object):
-    "This formats messages and provides access to workspace-wide data (user and channel metadata)."
-
-    # Class-level constants for precompilation of frequently-reused regular expressions
-    # URL detection relies on http://stackoverflow.com/a/1547940/1798683
-    _LINK_PAT = re.compile(r"<(https|http|mailto):[A-Za-z0-9_\.\-\/\?\,\=\#\:\@]+\|[^>]+>")
-    _MENTION_PAT = re.compile(r"<((?:#C|@[UB])\w+)(?:\|([A-Za-z0-9.-_]+))?>")
-    _HASHTAG_PAT = re.compile(r"(^| )#[A-Za-z][\w\.\-\_]+( |$)")
-
-    def __init__(self, USER_DATA, CHANNEL_DATA):
-        self.__USER_DATA = USER_DATA
-        self.__CHANNEL_DATA = CHANNEL_DATA
-
-    def find_user(self, message):
-        if message.get("user") == "USLACKBOT":
-            return User({"name":"slackbot"})
-        if message.get("subtype", "").startswith("bot_") and message["bot_id"] not in self.__USER_DATA:
-            bot_id = message["bot_id"]
-            logging.debug("bot addition for %s", bot_id)
-            if "bot_link" in message:
-                (bot_url, bot_name) = message["bot_link"].strip("<>").split("|", 1)
-            elif "username" in message:
-                bot_name = message["username"]
-                bot_url = None
-
-            self.__USER_DATA[bot_id] = User({
-                "user": bot_id,
-                "real_name": bot_name,
-                "bot_url": bot_url,
-                "is_bot": True,
-                "is_app_user": True
-            })
-        user_id = message.get("user") or message.get("bot_id")
-        if user_id in self.__USER_DATA:
-            return self.__USER_DATA.get(user_id)
-        logging.error("unable to find user in %s", message)
-
-    def render_text(self, message, process_markdown=True):
-        message = message.replace("<!channel>", "@channel")
-        message = self._slack_to_accepted_emoji(message)
-
-        # Handle mentions of users, channels and bots (e.g "<@U0BM1CGQY|calvinchanubc> has joined the channel")
-        message = self._MENTION_PAT.sub(self._sub_annotated_mention, message)
-        # Handle links
-        message = self._LINK_PAT.sub(self._sub_hyperlink, message)
-        # Handle hashtags (that are meant to be hashtags and not headings)
-        message = self._HASHTAG_PAT.sub(self._sub_hashtag, message)
-
-        # Introduce unicode emoji
-        message = emoji.emojize(message, use_aliases=True)
-
-        if process_markdown:
-            # Handle bold (convert * * to ** **)
-            message = re.sub(r'\*', "**", message)
-
-            message = markdown2.markdown(
-                message,
-                extras=[
-                    "cuddled-lists",
-                    # This gives us <pre> and <code> tags for ```-fenced blocks
-                    "fenced-code-blocks",
-                    "pyshell"
-                ]
-            ).strip()
-
-        # Special handling cases for lists
-        message = message.replace("\n\n<ul>", "<ul>")
-        message = message.replace("\n<li>", "<li>")
-
-        return message
-
-    def _slack_to_accepted_emoji(self, message):
-        # https://github.com/Ranks/emojione/issues/114
-        message = message.replace(":simple_smile:", ":slightly_smiling_face:")
-        return message
-
-    def _sub_annotated_mention(self, matchobj):
-        ref_id = matchobj.group(1)[1:]  # drop #/@ from the start, we don't care
-        annotation = matchobj.group(2)
-        if ref_id.startswith('C'):
-            mention_format = "<b>#{}</b>"
-            if not annotation:
-                channel = self.__CHANNEL_DATA.get(ref_id)
-                annotation = channel["name"] if channel else ref_id
-        else:
-            mention_format = "@{}"
-            if not annotation:
-                user = self.__USER_DATA.get(ref_id)
-                annotation = user.display_name if user else ref_id
-        return mention_format.format(annotation)
-
-    def _sub_hyperlink(self, matchobj):
-        compound = matchobj.group(0)[1:-1]
-        if len(compound.split("|")) == 2:
-            url, title = compound.split("|")
-        else:
-            url, title = compound, compound
-        result = "<a href=\"{url}\">{title}</a>".format(url=url, title=title)
-        return result
-
-    def _sub_hashtag(self, matchobj):
-        text = matchobj.group(0)
-
-        starting_space = " " if text[0] == " " else ""
-        ending_space = " " if text[-1] == " " else ""
-
-        return "{}<b>{}</b>{}".format(
-            starting_space,
-            text.strip(),
-            ending_space
-        )
 
 
 class LinkAttachment(object):

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -112,7 +112,7 @@ class Message(object):
         message = re.sub(r"(^| )#[A-Za-z0-9\.\-\_]+( |$)",
                          self._sub_hashtag, message)
         # Handle channel references
-        message = re.sub(r"<#C0\w+>", self._sub_channel_ref, message)
+        message = re.sub(r"<#C\w+>", self._sub_channel_ref, message)
         # Handle italics (convert * * to ** **)
         message = re.sub(r"(^| )\*[A-Za-z0-9\-._ ]+\*( |$)",
                          self._sub_bold, message)

--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -3,6 +3,7 @@ import os
 import glob
 import io
 
+from slackviewer.formatter import SlackFormatter
 from slackviewer.message import Message
 from slackviewer.user import User
 
@@ -131,6 +132,7 @@ class Reader(object):
 
         chats = {}
         empty_dms = []
+        formatter = SlackFormatter(self.__USER_DATA, data)
 
         for name in names:
 
@@ -150,7 +152,7 @@ class Reader(object):
                 with io.open(os.path.join(self._PATH, day), encoding="utf8") as f:
                     # loads all messages
                     day_messages = json.load(f)
-                    messages.extend([Message(self.__USER_DATA, data, d) for d in day_messages])
+                    messages.extend([Message(formatter, d) for d in day_messages])
 
             chats[name] = messages
 

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -132,8 +132,17 @@ body {
     color: #999999;
 }
 
-.channel_join .msg, .channel_topic .msg {
+.message-container .icon {
+    max-width: 10px;
+}
+
+.channel_join .msg, .channel_topic .msg,
+.bot_add .msg, .app_conversation_join .msg {
     font-style: italic;
+}
+
+.attachment-footer {
+    font-size: small;
 }
 
 .list {

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -67,11 +67,15 @@ body {
     overflow-y: scroll;
 }
 
+.message-container {
+    clear: left;
+    min-height: 56px; // height of image plus 20px padding
+}
 .message-container:first-child {
   margin-top: 20px;
 }
 
-.message-container img {
+.message-container .user_icon {
     background-color: rgb(248, 244, 240);
     width: 36px;
     height: 36px;
@@ -94,6 +98,11 @@ body {
     line-height: 1;
 }
 
+.message-container .user-email {
+    font-weight: normal;
+    font-style: italic;
+}
+
 .message-container .message {
     display: inline-block;
     vertical-align: top;
@@ -112,6 +121,15 @@ body {
 
 .message-container .message .msg {
     line-height: 1.5;
+}
+
+.message-container .message-attachment {
+    padding-left: 5px;
+    border-left: 2px gray solid;
+}
+
+.message-container .message-attachment .service-name {
+    color: #999999;
 }
 
 .channel_join .msg, .channel_topic .msg {
@@ -164,4 +182,8 @@ a:hover {
 
 .close {
   display: none;
+}
+
+@media screen {
+    .print-only { display: none }
 }

--- a/slackviewer/templates/util.html
+++ b/slackviewer/templates/util.html
@@ -14,21 +14,47 @@
 {% macro render_message(message, preview_size) -%}
     <div class="message-container{%if message.subtype %} {{message.subtype}}{%endif%}">
         <div id="{{ message.id }}">
-            <img src="{{ message.img }}" class="user_icon" />
+            {%if message.img%}<img src="{{ message.img }}" class="user_icon" />{%else%}<div class="user_icon"></div>{%endif%}
             <div class="message">
-                <div class="username">{{ message.username }}</div>
+                <div class="username">{{ message.username }}
+                    {%if message.user.email%} <span class="print-only user-email">({{message.user.email}})</span>{%endif%}
+                </div>
                 <a href="#{{ message.id}}"><div class="time">{{ message.time }}</div></a>
                 <div class="msg">
                     {{ message.msg|safe }}
                     {% for attachment in message.attachments -%}
-                        <div class="message-attachment">
+                        <div class="message-attachment"
+                            {%if attachment.color %}style="border-color: #{{attachment.color}}"{%endif%}>
                             {%if attachment.service_name %}<div class="service-name">{{ attachment.service_name }}</div>{%endif%}
+                            {%if attachment.author_name%}
+                                <div class="attachment-author">
+                                    <img src="{{attachment.author_icon}}" class="icon">
+                                    {%if attachment.author_link%}<a href="{{attachment.author_link}}">{%endif%}
+                                    {{attachment.author_name}}
+                                    {%if attachment.author_link%}</a><span class="print-only">({{attachment.author_link}})</span>{%endif%}
+                                </div>
+                            {%endif%}
+                            {%if attachment.pretext %}<div class="pre-text">{{attachment.pretext}}</div>{%endif%}
                             <div class="link-title"><a href="{{ attachment.title_link }}">{{ attachment.title }}</a></div>
-                            <div class="link-text">{{attachment.text}}</div>
+                            <div class="link-text">
+                                {{attachment.text}}
+                            </div>
+                            {%for field in attachment.fields %}
+                                <div class="attachment-field">
+                                    {%if field.title %}<div class="field-title">{{field.title}}</div>{%endif%}
+                                    {{field.value}}
+                                </div>
+                            {%endfor%}
                             {{ render_thumbnail(attachment, preview_size) }}
                             {% if attachment.original_url %}
                                 <div class="print-only">Original URL: {{attachment.original_url}}</div>
                             {% endif %}
+                            {%if attachment.footer%}
+                                <div class="attachment-footer">
+                                    <img src="{{attachment.footer_icon}}" class="icon" />
+                                    {{attachment.footer}}
+                                </div>
+                            {%endif%}
                         </div>
                     {% endfor  %}
                     {% for file in message.files  -%}

--- a/slackviewer/templates/util.html
+++ b/slackviewer/templates/util.html
@@ -1,0 +1,44 @@
+{% macro render_thumbnail(parent, thumbnail_size=None) -%}
+    {% set thumb = parent.thumbnail(thumbnail_size) %}
+    {% if thumb %}
+        <a href="{{parent.link}}">
+            <img class="preview" src="{{thumb.src}}"
+                {% if thumb.width %}width="{{thumb.width}}"{% endif %}
+                {% if thumb.height %} height="{{thumb.height}}"{% endif %} />
+        </a>
+    {% else %}
+        <!-- no preview available -->
+    {% endif %}
+{%- endmacro %}
+
+{% macro render_message(message, preview_size) -%}
+    <div class="message-container{%if message.subtype %} {{message.subtype}}{%endif%}">
+        <div id="{{ message.id }}">
+            <img src="{{ message.img }}" class="user_icon" />
+            <div class="message">
+                <div class="username">{{ message.username }}</div>
+                <a href="#{{ message.id}}"><div class="time">{{ message.time }}</div></a>
+                <div class="msg">
+                    {{ message.msg|safe }}
+                    {% for attachment in message.attachments -%}
+                        <div class="message-attachment">
+                            {%if attachment.service_name %}<div class="service-name">{{ attachment.service_name }}</div>{%endif%}
+                            <div class="link-title"><a href="{{ attachment.title_link }}">{{ attachment.title }}</a></div>
+                            <div class="link-text">{{attachment.text}}</div>
+                            {{ render_thumbnail(attachment, preview_size) }}
+                            {% if attachment.original_url %}
+                                <div class="print-only">Original URL: {{attachment.original_url}}</div>
+                            {% endif %}
+                        </div>
+                    {% endfor  %}
+                    {% for file in message.files  -%}
+                        <div class="message-upload">
+                            <div class="link-title"><a href="{{ file.link }}">{{ file.title }}</a></div>
+                            {{ render_thumbnail(file, preview_size) }}
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+{%- endmacro %}

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+{% from "util.html" import render_message %}
 <head>
     <meta charset="UTF-8">
     <title>Slack Export - #{{ name }}</title>
@@ -55,17 +56,7 @@
     </div>
     <div class="messages">
         {% for message in messages %}
-            <div class="message-container{%if message.subtype %} {{message.subtype}}{%endif%}">
-            <div id="{{ message.id }}">
-                <img src="{{ message.img }}"/>
-                <div class="message">
-                    <div class="username">{{ message.username }}</div>
-                    <a href="#{{ message.id}}"><div class="time">{{ message.time }}</div></a>
-                    <div class="msg">{{ message.msg|safe }}</div>
-                </div>
-            </div>
-            </div>
-            <br/>
+            {{render_message(message)}}
         {% endfor %}
     </div>
 </div>

--- a/slackviewer/user.py
+++ b/slackviewer/user.py
@@ -1,4 +1,5 @@
 # User info wrapper object
+import logging
 
 class User(object):
     """
@@ -24,20 +25,30 @@ class User(object):
         for k in self._NAME_KEYS:
             if self._raw.get(k):
                 return self._raw[k]
-            if self._raw["profile"].get(k):
+            if "profile" in self._raw and self._raw["profile"].get(k):
                 return self._raw["profile"][k]
         return self._raw["name"]
 
     @property
     def email(self):
-        "Shortcut property for finding the e-mail address."
-        return self._raw["profile"]["email"]
+        "Shortcut property for finding the e-mail address or bot URL."
+        if "profile" in self._raw:
+            email = self._raw["profile"].get("email")
+        elif "bot_url" in self._raw:
+            email = self._raw["bot_url"]
+        else:
+            email = None
+        if not email:
+            logging.debug("No email found for %s", self._raw.get("name"))
+        return email
 
     def image_url(self, pixel_size=None):
         """
         Get the URL for the user icon in the desired pixel size, if it exists. If no
         size is supplied, give the URL for the full-size image.
         """
+        if "profile" not in self._raw:
+            return
         profile = self._raw["profile"]
         if (pixel_size):
             img_key = "image_%s" % pixel_size

--- a/slackviewer/user.py
+++ b/slackviewer/user.py
@@ -31,7 +31,9 @@ class User(object):
 
     @property
     def email(self):
-        "Shortcut property for finding the e-mail address or bot URL."
+        """
+        Shortcut property for finding the e-mail address or bot URL.
+        """
         if "profile" in self._raw:
             email = self._raw["profile"].get("email")
         elif "bot_url" in self._raw:


### PR DESCRIPTION
Work that was originally undertaken to update upload-preview and link-preview rendering, which expanded to handle more complicated bot-generated messages (from e.g. the Jenkins or Github bots), and culminated in some significant refactoring, in order to make it simpler to fix various rendering issues that were found in that process.

Commits in the branch are separated out as cleanly as seemed possible, to give some traceability, but at a high level:

* moved as much HTML generation as possible from the python code to the template
* updated regular-expression-based parsing to have fewer special cases and to handle the IDs as currently generated by slack (which don't all match the older regex)
* handle most special-case slack markup directly, rather than translating it to markdown (there are unquestionably some cases that are handled badly by this, which are different from the cases that were handled badly before: markup engines are hard to reverse-engineer)
* handle more cases of the "attachments" list than were previously handled
