### PR TITLE
Added a single-file export command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ __pycache__/
 # C extensions
 *.so
 
+# Single-file exports
+/*.html
+/*.pdf
+
 # Distribution / packaging
 .Python
 env/

--- a/slackviewer/archive.py
+++ b/slackviewer/archive.py
@@ -4,6 +4,8 @@ import os
 import zipfile
 import io
 
+from os.path import basename, splitext
+
 import slackviewer
 from slackviewer.constants import SLACKVIEWER_TEMP_PATH
 from slackviewer.utils.six import to_unicode, to_bytes
@@ -101,3 +103,24 @@ def create_archive_info(filepath, extracted_path, archive_sha=None):
         s = json.dumps(archive_info, ensure_ascii=False)
         s = to_unicode(s)
         f.write(s)
+
+
+def get_export_info(archive_name):
+    """
+    Given a file or directory, extract it and return information that will be used in
+    an export printout: the basename of the file, the name stripped of its extension, and
+    our best guess (based on Slack's current naming convention) of the name of the
+    workspace that this is an export of.
+    """
+    extracted_path = extract_archive(archive_name)
+    base_filename = basename(archive_name)
+    (noext_filename, _) = splitext(base_filename)
+    # Typical extract name: "My Friends and Family Slack export Jul 21 2018 - Sep 06 2018"
+    # If that's not the format, we will just fall back to the extension-free filename.
+    (workspace_name, _) = noext_filename.split(" Slack export ", 1)
+    return {
+        "readable_path": extracted_path,
+        "basename": base_filename,
+        "stripped_name": noext_filename,
+        "workspace_name": workspace_name,
+    }

--- a/slackviewer/cli.py
+++ b/slackviewer/cli.py
@@ -1,6 +1,7 @@
 import click
 import pkgutil
 import shutil
+import os.path
 
 from datetime import datetime
 

--- a/slackviewer/cli.py
+++ b/slackviewer/cli.py
@@ -1,10 +1,14 @@
 import click
+import pkgutil
 import shutil
 
-import os
+from datetime import datetime
 
 from slackviewer.constants import SLACKVIEWER_TEMP_PATH
 from slackviewer.utils.click import envvar, flag_ennvar
+from slackviewer.reader import Reader
+from slackviewer.archive import get_export_info
+from jinja2 import Environment, PackageLoader
 
 
 @click.group()
@@ -25,3 +29,26 @@ def clean(wet):
             print("Nothing to remove! {} does not exist.".format(SLACKVIEWER_TEMP_PATH))
     else:
         print("Run with -w to remove {}".format(SLACKVIEWER_TEMP_PATH))
+
+
+@cli.command(help="Generates a single-file printable export for an archive file or directory")
+@click.argument('archive_dir')
+def export(archive_dir):
+    css = pkgutil.get_data('slackviewer','static/viewer.css').decode('utf-8')
+    tmpl = Environment(loader=PackageLoader('slackviewer')).get_template("export_single.html")
+    export_file_info = get_export_info(archive_dir)
+    r = Reader(export_file_info["readable_path"])
+    channel_list = sorted(
+        [{"channel_name": k, "messages": v} for (k,v) in r.compile_channels().iteritems()],
+        key=lambda d: d["channel_name"]
+    )
+
+    html = tmpl.render(
+        css=css,
+        generated_on=datetime.now(),
+        workspace_name=export_file_info["workspace_name"],
+        source_file=export_file_info["basename"],
+        channels=channel_list
+    )
+    outfile = open(export_file_info["stripped_name"] + '.html', 'w')
+    outfile.write(html.encode('utf-8'))

--- a/slackviewer/templates/export_single.html
+++ b/slackviewer/templates/export_single.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+{% from "util.html" import render_message %}
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Slack Export - {{ workspace_name }}</title>
+    <style>
+        {{css}}
+        .channel-block {
+            page-break-after: always;
+        }
+        .export-metadata {
+            line-height: 2;
+        }
+    </style>
+</head>
+<body>
+    <h1>Export of Slack Workspace "{{workspace_name}}"</h1>
+    <table class="export-metadata">
+        <tr><td>Generated from file:</td><td><b>{{source_file}}</b></td></tr>
+        <tr><td>Generated on:</td><td> <b>{{generated_on.strftime("%F %H:%M:%S")}}</b></td></tr>
+    </table>
+    </div>
+    {% for channel in channels %}
+    <div class="channel-block">
+        <h2>Messages in #{{channel.channel_name}}</h2>
+        <div class="message-list">
+            {% for message in channel.messages %}
+                {{render_message(message)}}
+            {% endfor %}
+        </div>
+    </div>
+    {% endfor %}
+</body>
+</html>


### PR DESCRIPTION
Added a new CLI command to export an entire workspace into a single HTML file, together with accompanying utility and template code, as suggested in #77.

Depends on #78 for utility-macro imports—this is a cherry-pick to avoid conflicts if that gets squash-merged.