### PR TITLE
Emoji reactions

### DIFF
--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -75,11 +75,25 @@ class Message(object):
             text = self._formatter.render_text(text)
         return text
 
+    def user_message(self, user_id):
+       return {"user": user_id}
+
+    def usernames(self, reaction):
+        return [
+            self._formatter.find_user(self.user_message(user_id)).display_name
+            for user_id
+            in reaction.get("users")
+            if self._formatter.find_user(self.user_message(user_id))
+        ]
+
     @property
     def reactions(self):
         reactions = self._message.get("reactions", [])
         return [
-            {"usernames": [user for user in reaction.get("users")], "name":':'+reaction.get("name")+':'}
+            {
+                "usernames": self.usernames(reaction),
+                "name": emoji.emojize(':'+reaction.get("name")+':', use_aliases=True)
+            }
             for reaction in reactions
         ]
 

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -76,6 +76,14 @@ class Message(object):
         return text
 
     @property
+    def reactions(self):
+        reactions = self._message.get("reactions", [])
+        return [
+            {"usernames": [user for user in reaction.get("users")], "name":':'+reaction.get("name")+':'}
+            for reaction in reactions
+        ]
+
+    @property
     def img(self):
         try:
             return self.user.image_url(self._DEFAULT_USER_ICON_SIZE)

--- a/slackviewer/templates/util.html
+++ b/slackviewer/templates/util.html
@@ -63,6 +63,11 @@
                             {{ render_thumbnail(file, preview_size) }}
                         </div>
                     {% endfor %}
+                    <div class="message-reaction">
+                        {% for reaction in message.reactions %}
+                            {{ reaction.name }}
+                        {% endfor %}
+                    </div>
                 </div>
             </div>
         </div>

--- a/slackviewer/templates/util.html
+++ b/slackviewer/templates/util.html
@@ -63,12 +63,12 @@
                             {{ render_thumbnail(file, preview_size) }}
                         </div>
                     {% endfor %}
-                    <div class="message-reaction">
-                        {% for reaction in message.reactions %}
-                            {{ reaction.name }}
-                        {% endfor %}
-                    </div>
-                </div>
+                    {% for reaction in message.reactions %}
+                        <div class="message-reaction">
+                        {{ reaction.name }} {{ reaction.usernames|join(', ') }}
+                        </div>
+                    {% endfor %}
+		</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
fix for https://github.com/hfaran/slack-export-viewer/issues/68

![screenshot from 2019-01-04 18-51-22](https://user-images.githubusercontent.com/300279/50706171-5bd1f480-105d-11e9-81d9-e11cd427bfca.png)

formatter should probably be refactored to no require a message in `find_user()` and there should maybe be some more work to beautify the output. but it works