### PR TITLE
Fix broken channel name parsing

### DIFF
--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -42,7 +42,7 @@ def configure_app(app, archive, channels, no_sidebar, no_external_references, de
               help="If you do not want a browser to open "
                    "automatically, set this.")
 @click.option('--channels', type=click.STRING,
-              default=envvar("SEV_CHANNELS", ''),
+              default=envvar("SEV_CHANNELS", None),
               help="A comma separated list of channels to parse.")
 @click.option('--no-sidebar', is_flag=True,
               default=flag_ennvar("SEV_NO_SIDEBAR"),


### PR DESCRIPTION
The previous change added a `--channels` flag that uses a default value of
`''` when no argument is passed. It performs checking that it is a string
type before splitting, and then uses that in the list comprehension to
build all the channel names. As such, we would filter out all the
channel names, and cause a IndexError: list index out of range