### PR TITLE
Fix typo in no_sidebar template variable name

### DIFF
--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <div id="slack-archive-viewer">
-    {% if show_sidebar %}
+    {% if not no_sidebar %}
     <div id="sidebar">
         <h3 id="channel-title">Public Channels</h3>
         <ul class="list" id="channel-list">


### PR DESCRIPTION
When the `--no-sidebar` flag was added, we accidentally were using the
wrong template parameter in the template views. As such, the sidebar
would never show up due to a typo. This changes the template variable to
`no_sidebar` and inverts the condition, instead of the erroneous
`show_sidebar`.