### PR TITLE
[bug] short field is optional -- default it to False if not present

### DIFF
--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -192,6 +192,6 @@ class LinkAttachment(object):
         if fields:
             logging.debug("Rendering with markdown markdown %s for %s", process_markdown, fields)
         return [
-            {"title": e["title"], "short": e["short"], "value": self._formatter.render_text(e["value"], process_markdown)}
+            {"title": e["title"], "short": e.get("short", False), "value": self._formatter.render_text(e["value"], process_markdown)}
             for e in fields
         ]


### PR DESCRIPTION
According to Slack's documentation, the 'short' field is optional. Defaulting it to False as to not throw a KeyError. 

https://api.slack.com/docs/message-attachments
```
short
An optional flag indicating whether the value is short enough to be displayed side-by-side with other values.
```