### PR TITLE
Handle case on home page where no channels exist in the export

### DIFF
--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -98,4 +98,4 @@ def index():
     elif mpims:
         return mpim_name(mpims[0])
     else:
-        print("Not sure where to start- Try adding a Private group, Public group or DM to the slack-export ")
+        return "No content was found in your export that we could render."

--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -84,16 +84,18 @@ def mpim_name(name):
 def index():
     channels = list(flask._app_ctx_stack.channels.keys())
     groups = list(flask._app_ctx_stack.groups.keys())
-    dm_users = list(flask._app_ctx_stack.dm_users)
-    mpim_users = list(flask._app_ctx_stack.mpim_users)
-    if(len(channels) > 0):
+    dms = list(flask._app_ctx_stack.dms.keys())
+    mpims = list(flask._app_ctx_stack.mpims.keys())
+    if channels:
         if "general" in channels:
             return channel_name("general")
         else:
             return channel_name(channels[0])
-    elif(len(groups) >0):
-        return(group_name(groups[0]))
-    elif(len(dm_users) >0):
-        return(dm_id(dm_users[0]))
+    elif groups:
+        return group_name(groups[0])
+    elif dms:
+        return dm_id(dms[0])
+    elif mpims:
+        return mpim_name(mpims[0])
     else:
         print("Not sure where to start- Try adding a Private group, Public group or DM to the slack-export ")

--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -83,7 +83,17 @@ def mpim_name(name):
 @app.route("/")
 def index():
     channels = list(flask._app_ctx_stack.channels.keys())
-    if "general" in channels:
-        return channel_name("general")
+    groups = list(flask._app_ctx_stack.groups.keys())
+    dm_users = list(flask._app_ctx_stack.dm_users)
+    mpim_users = list(flask._app_ctx_stack.mpim_users)
+    if(len(channels) > 0):
+        if "general" in channels:
+            return channel_name("general")
+        else:
+            return channel_name(channels[0])
+    elif(len(groups) >0):
+        return(group_name(groups[0]))
+    elif(len(dm_users) >0):
+        return(dm_id(dm_users[0]))
     else:
-        return channel_name(channels[0])
+        print("Not sure where to start- Try adding a Private group, Public group or DM to the slack-export ")


### PR DESCRIPTION
This is an effort to handle Issue #105 - this error occurs when the output from https://github.com/zach-snell/slack-export does not include a public channel. This quick fix checks whether any public channels are included in the request, and if not moves on to private groups, direct messages etc.  

Resolves #105 