### PR TITLE
Support for output generated by wayslack

### DIFF
--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -73,7 +73,11 @@ class Reader(object):
             if dm["id"] not in self._EMPTY_DMS:
                 # added try catch for users from shared workspaces not in current workspace
                 try:
-                    dm_members = {"id": dm["id"], "users": [self.__USER_DATA[m] for m in dm["members"]]}
+                    if "members" in dm:
+                        users = dm["members"]
+                    if "user" in dm:
+                        users = [dm["user"]]
+                    dm_members = {"id": dm["id"], "users": [self.__USER_DATA[m] for m in users]}
                     all_dms_users.append(dm_members)
                 except KeyError:
                     dm_members = None

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -38,7 +38,8 @@
             {% for dm in dm_users %}
                 <li class="dm{% if dm['id'] == id %} active{% endif %}">
                     <a href="{{ url_for('dm_id', id=dm['id']) }}">
-                        &#128100; {{ dm["users"][0].real_name if dm["users"][0].real_name else dm["users"][0].name }}, {{ dm["users"][1].real_name if dm["users"][1].real_name else dm["users"][1].name }}
+                        &#128100; {{ dm["users"][0].real_name if dm["users"][0].real_name else dm["users"][0].name }}
+                        {% if dm["users"][1] %}, {{ dm["users"][1].real_name if dm["users"][1].real_name else dm["users"][1].name }}{% endif %}
                     </a>
                 </li>
             {% endfor %}


### PR DESCRIPTION
Direct messages does not have `members` array. It has only one "remote" user id. This avoids void error and keeps everything backward compatible.