### PR TITLE
add USLACKBOT when Reader reads "users.json"

### DIFF
--- a/slackviewer/formatter.py
+++ b/slackviewer/formatter.py
@@ -27,8 +27,6 @@ class SlackFormatter(object):
         self.__CHANNEL_DATA = CHANNEL_DATA
 
     def find_user(self, message):
-        if message.get("user") == "USLACKBOT":
-            return User({"name":"slackbot"})
         if message.get("subtype", "").startswith("bot_") and "bot_id" in message and message["bot_id"] not in self.__USER_DATA:
             bot_id = message["bot_id"]
             logging.debug("bot addition for %s", bot_id)

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -38,12 +38,8 @@ class Message(object):
             # In case this is a bot or something, we fallback to "username"
             if "username" in self._message:
                 return self._message["username"]
-            # If that fails to, it's probably USLACKBOT...
-            if "user" in self._message:
-                if self.user_id == "USLACKBOT":
-                    return "slackbot"
-                else:
-                    return self.user_id
+            elif "user" in self._message:
+                return self.user_id
             elif "bot_id" in self._message:
                 return self._message["bot_id"]
             else:

--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -32,7 +32,7 @@ class Reader(object):
                     "image_512": "https://a.slack-edge.com/1801/img/slackbot_512.png",
                 }
             }
-            self.__USER_DATA["USLACKBOT"] = User(slackbot)
+            self.__USER_DATA.setdefault("USLACKBOT", User(slackbot))
 
     ##################
     # Public Methods #

--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -20,6 +20,19 @@ class Reader(object):
         # TODO: Make sure this works
         with io.open(os.path.join(self._PATH, "users.json"), encoding="utf8") as f:
             self.__USER_DATA = {u["id"]: User(u) for u in json.load(f)}
+            slackbot = {
+                "id": "USLACKBOT",
+                "name": "slackbot",
+                "profile": {
+                    "image_24": "https://a.slack-edge.com/0180/img/slackbot_24.png",
+                    "image_32": "https://a.slack-edge.com/2fac/plugins/slackbot/assets/service_32.png",
+                    "image_48": "https://a.slack-edge.com/2fac/plugins/slackbot/assets/service_48.png",
+                    "image_72": "https://a.slack-edge.com/0180/img/slackbot_72.png",
+                    "image_192": "https://a.slack-edge.com/66f9/img/slackbot_192.png",
+                    "image_512": "https://a.slack-edge.com/1801/img/slackbot_512.png",
+                }
+            }
+            self.__USER_DATA["USLACKBOT"] = User(slackbot)
 
     ##################
     # Public Methods #


### PR DESCRIPTION
related with https://github.com/hfaran/slack-export-viewer/issues/125

I added USLACKBOT user when reading "users.json" so that developers don't have to care about exceptions caused by slackbot. I don't have archives including direct messages, so I couldn't test the code with this issue.

Pros:
- Developers do not have to care about slackbot elsewhere.
- We can easily add another bot when the slack log format changes. The code might be better if we replace slackbot = {...} dictionary with a json file but I didn't do it for no reason.

Cons:
- Adding a non-existent user to __USER_DATA might not be the greatest approach.