### PR TITLE
pipsi is unmaintained and the creator recommends pipx instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Slack team's export (instead of having to dive into hundreds of JSON files).
 
 ## Installation
 
-I recommend [`pipsi`](https://github.com/mitsuhiko/pipsi) for a nice 
+I recommend [`pipx`](https://github.com/pipxproject/pipx) for a nice
 isolated install.
 
 ```bash
-pipsi install slack-export-viewer
+pipx install slack-export-viewer
 ```
 
 Or just feel free to use `pip` as you like.


### PR DESCRIPTION
Since pipsi is no longer maintained, I figured you might want the readme to recommend the pipx alternative instead.