### PR TITLE
Don't crash if the message has no "text"

### DIFF
--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -251,7 +251,7 @@ class Reader(object):
                 location = grouping[0] + 1
                 for reply in grouping[1]:
                     msgtext = reply._message.get("text")
-                    if not msgtext or msgtext.startswith("**Thread Reply:**"):
+                    if not msgtext or not msgtext.startswith("**Thread Reply:**"):
                         reply._message["text"] = "**Thread Reply:** {}".format(msgtext)
                     channel_data[channel_name].insert(location, reply)
                     location += 1

--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -250,8 +250,9 @@ class Reader(object):
             for grouping in sorted_threads.items():
                 location = grouping[0] + 1
                 for reply in grouping[1]:
-                    if not reply._message["text"].startswith("**Thread Reply:**"):
-                        reply._message["text"] = "**Thread Reply:** {}".format(reply._message['text'])
+                    msgtext = reply._message.get("text")
+                    if not msgtext or msgtext.startswith("**Thread Reply:**"):
+                        reply._message["text"] = "**Thread Reply:** {}".format(msgtext)
                     channel_data[channel_name].insert(location, reply)
                     location += 1
             # threads location hotfix


### PR DESCRIPTION
Fixes #148 

What has changed:
- Instead of directly addressing the _message["text"] which may cause `KeyNotFound` exception, do it gently, with `get`.