### PR TITLE
Make images responsive and prevent hyperlinks from being wider than viewport

### DIFF
--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -59,11 +59,12 @@ body {
 }
 
 .messages {
-    width: calc(100vw - 305px);
+    width: calc(100vw - 325px);
     height: 100vh;
     text-align: left;
     display: inline-block;
     padding-left: 20px;
+    padding-right: 20px;
     overflow-y: scroll;
 }
 
@@ -71,8 +72,13 @@ body {
     clear: left;
     min-height: 56px; // height of image plus 20px padding
 }
+
 .message-container:first-child {
-  margin-top: 20px;
+    margin-top: 20px;
+}
+
+.message-container:last-child {
+    margin-bottom: 20px;
 }
 
 .message-container .user_icon {
@@ -123,9 +129,14 @@ body {
     line-height: 1.5;
 }
 
+.message-container .message .msg a {
+    overflow-wrap: anywhere;
+}
+
 .message-container .message-attachment {
     padding-left: 5px;
     border-left: 2px gray solid;
+    overflow-wrap: anywhere;
 }
 
 .message-container .message-attachment .service-name {
@@ -195,4 +206,9 @@ a:hover {
 
 @media screen {
     .print-only { display: none }
+}
+
+img.preview {
+    max-width: 100%;
+    height: auto;
 }


### PR DESCRIPTION
### Summary of changes:

1. **Preview images are now responsive.** 
    - Previously, if a preview image was wider than the content area, it would still be displayed at its full size and the content area would have a horizontal scrollbar.
    - Now, the image will be "shrunken" down to fit within the content area, and will no longer cause a horizontal scrollbar to appear. This is shown in the following two screenshots.
    - ![image](https://user-images.githubusercontent.com/7143133/187052449-b6461d14-e786-4ab8-b185-bdc2cf006c76.png)
    - ![image](https://user-images.githubusercontent.com/7143133/187052460-9aa6be7d-7525-4adb-b571-16f4d58eed10.png)
    - **Exception:** :warning: I have noticed that, if an image does not load (e.g. the referenced image does not exist), the resulting "placeholder box" is not responsive; in which case, a horizontal scrollbar does appear (screenshot below).
    - ![image](https://user-images.githubusercontent.com/7143133/187052321-60c3253a-4ddc-45a6-91bb-8ecddd467c6c.png)
1. **Long hyperlinks now wrap at any character.**
    - Previously, some hyperlinks could be wider than the content area, causing the content area to have a horizontal scrollbar.
    - Now, those hyperlinks wrap, and will no longer cause a horizontal scrollbar to appear.
1. **The messages now have a margin on the right and bottom.**
    - Previously, the messages would touch the right edge of the viewport (i.e. no margin). Similarly, the final message would touch the bottom edge of the viewport (i.e. no margin).
    - Now, there is a 20-pixel margin in both places.