### PR TITLE
avoid crashing if mpim directory does not exist in the export

### DIFF
--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -64,7 +64,7 @@ def dm_id(id):
 
 @app.route("/mpim/<name>/")
 def mpim_name(name):
-    messages = flask._app_ctx_stack.mpims[name]
+    messages = flask._app_ctx_stack.mpims.get(name, list())
     channels = list(flask._app_ctx_stack.channels.keys())
     groups = list(flask._app_ctx_stack.groups.keys())
     dm_users = list(flask._app_ctx_stack.dm_users)


### PR DESCRIPTION
When `mpim.json` contains a mpim that was empty (did not contain any messages), the directory `mpim-....-1` may not exist.

This fix prevents "Internal Server Error" when accessing one of such conversations.

Sample error from the backend:
```
Traceback (most recent call last):
  File "/Users/rustam/wp/_thirdparty/slack-export-viewer/venv/lib/python3.9/site-packages/werkzeug/serving.py", line 335, in run_wsgi
    execute(self.server.app)
  File "/Users/rustam/wp/_thirdparty/slack-export-viewer/venv/lib/python3.9/site-packages/werkzeug/serving.py", line 322, in execute
    application_iter = app(environ, start_response)
  File "/Users/rustam/wp/_thirdparty/slack-export-viewer/venv/lib/python3.9/site-packages/flask/app.py", line 2548, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/rustam/wp/_thirdparty/slack-export-viewer/venv/lib/python3.9/site-packages/flask/app.py", line 2528, in wsgi_app
    response = self.handle_exception(e)
  File "/Users/rustam/wp/_thirdparty/slack-export-viewer/venv/lib/python3.9/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/rustam/wp/_thirdparty/slack-export-viewer/venv/lib/python3.9/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/rustam/wp/_thirdparty/slack-export-viewer/venv/lib/python3.9/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/rustam/wp/_thirdparty/slack-export-viewer/venv/lib/python3.9/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/Users/rustam/wp/_thirdparty/slack-export-viewer/slackviewer/app.py", line 67, in mpim_name
    messages = flask._app_ctx_stack.mpims[name]
KeyError: 'mpdm-foo--bar--baz-1'
```