### PR TITLE
Support utf-8 channel name

### DIFF
--- a/slackviewer/archive.py
+++ b/slackviewer/archive.py
@@ -69,7 +69,12 @@ def extract_archive(filepath):
         # Extract zip
         with zipfile.ZipFile(filepath) as zip:
             print("{} extracting to {}...".format(filepath, extracted_path))
-            zip.extractall(path=extracted_path)
+            for info in zip.infolist():
+                print(info.filename)
+                info.filename = info.filename.encode("cp437").decode("utf-8")
+                print(info.filename)
+                zip.extract(info,path=extracted_path)
+
 
         print("{} extracted to {}".format(filepath, extracted_path))
 


### PR DESCRIPTION
Because the zipfile exported from Slack encodes file name by cp437, we have to convert file name to utf-8 to support channel name in utf-8 codes like channel names in Japanese.