### PR TITLE
Do not crash and burn if "replies" is missing "user" or "ts" entry

### DIFF
--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -227,7 +227,7 @@ class Reader(object):
                         reply_list.append(reply)
                     reply_objects = []
                     for item in reply_list:
-                        item_lookup_key = (item['user'], item['ts'])
+                        item_lookup_key = (item.get('user'), item.get('ts'))
                         item_replies = user_ts_lookup.get(item_lookup_key)
                         if item_replies is not None:
                             reply_objects.extend(item_replies)


### PR DESCRIPTION
Hey @hfaran ,

One of the Slackdump users bumped into this issue, where the Slack API does not return the complete "replies" section for a message.  Full details are available in https://github.com/rusq/slackdump/issues/222

In brief, this is how the error looks like
```
  File "C:\Users\User\.local\pipx\venvs\slack-export-viewer\Lib\site-packages\slackviewer\reader.py", line 189, in _create_messages
    chats = self._build_threads(chats)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\User\.local\pipx\venvs\slack-export-viewer\Lib\site-packages\slackviewer\reader.py", line 230, in _build_threads
    item_lookup_key = (item['user'], item['ts'])
                       ~~~~^^^^^^^^
KeyError: 'user'
```

This happens because one or more messages have incomplete "replies" value, i.e.:
```json
    "replies": [
      {
        "ts": "1579562553.009200"
      }
],
```
While it should look like this:
```json
    "replies": [
      {
        "user": "US6CXSEBU",
        "ts": "1579562553.009200"
      }
    ],
```

This causes `_build_threads` to panic.

**Possible improvements**

This is a "quick" fix.  Maybe it would make sense to log the username, or the message ID if that happens, so that the user could troubleshoot.  Let me know if that's what you'd be interested in and I could spend some more time on this.

Thank you for looking into this.