### PR TITLE
Modify styling of channel replies for a nested appearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ Run with -w to remove C:\Users\hamza\AppData\Local\Temp\_slackviewer
 Removing C:\Users\hamza\AppData\Local\Temp\_slackviewer...
 ```
 
+## Local Development
+
+After installing the requirements in requirements.txt and dev-requirements.txt, 
+define `FLASK_APP` as `main` and select any channels desired from an export:
+
+```bash
+export FLASK_APP=main && export SEV_CHANNELS=general
+```
+
+Start a development server by running `app.py` in the root directory:
+
+```bash
+python3 app.py -z /Absolute/path/to/archive.zip --debug
+```
+
 ## Acknowledgements
 
 Credit to Pieter Levels whose [blog post](https://levels.io/slack-export-to-html/) and PHP script I used as a jumping off point for this.

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -70,7 +70,7 @@ body {
 
 .message-container {
     clear: left;
-    min-height: 56px; // height of image plus 20px padding
+    min-height: 56px;
 }
 
 .message-container:first-child {
@@ -89,6 +89,18 @@ body {
     display: inline-block;
     vertical-align: top;
     margin-right: 0.65em;
+    float: left;
+}
+
+.message-container .user_icon_reply {
+    background-color: rgb(248, 244, 240);
+    width: 36px;
+    height: 36px;
+    border-radius: 0.2em;
+    display: inline-block;
+    vertical-align: top;
+    margin-right: 0.65em;
+    margin-left: 40px;
     float: left;
 }
 
@@ -116,6 +128,13 @@ body {
     width: calc(100% - 3em);
 }
 
+.message-container .reply {
+    vertical-align: top;
+    line-height: 1;
+    width: calc(100% - 3em);
+    margin-left: 80px;
+}
+
 .message-container .msg p {
     white-space: pre-wrap;
 }
@@ -129,7 +148,15 @@ body {
     line-height: 1.5;
 }
 
+.message-container .reply .msg {
+    line-height: 1.5;
+}
+
 .message-container .message .msg a {
+    overflow-wrap: anywhere;
+}
+
+.message-container .reply .msg a {
     overflow-wrap: anywhere;
 }
 

--- a/slackviewer/templates/util.html
+++ b/slackviewer/templates/util.html
@@ -11,13 +11,19 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro render_message(message, preview_size=None, no_external_references=False) -%}
-    <div class="message-container{%if message.subtype %} {{message.subtype}}{%endif%}">
+{% macro render_message(message, preview_size=None, no_external_references=False, reply=False) -%}
+    <div class="message-container{%if message.subtype %} {{message.subtype}} {% elif reply.subtype %} {{reply.subtype}} {%endif%}">
         <div id="{{ message.id }}">
-            {% if not no_external_references %}
+            {% if not no_external_references and not reply %}
                 {% if message.img %}<img src="{{ message.img }}" class="user_icon" />{%else%}<div class="user_icon"></div>{%endif%}
+            {% elif not no_external_references and reply %}
+                {% if message.img %}<img src="{{ message.img }}" class="user_icon_reply" />{%else%}<div class="user_icon_reply"></div>{%endif%}
             {% endif %}
-            <div class="message">
+            {% if not reply %}
+                <div class="message">
+            {% else %}
+                <div class="reply">
+            {% endif %}
                 <div class="username">{{ message.username }}
                     {%if message.user.email%} <span class="print-only user-email">({{message.user.email}})</span>{%endif%}
                 </div>

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -61,7 +61,13 @@
     {% endif %}
     <div class="messages">
         {% for message in messages %}
-            {{render_message(message, None, no_external_references)}}
+            {% if message.msg %}
+                {% if "Thread Reply:" in message.msg %}
+                    {{render_message(message, None, no_external_references, reply=True)}}
+                {% else %}
+                    {{render_message(message, None, no_external_references, reply=False)}}
+                {% endif %}
+            {% endif %}
         {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
Replies to messages in channels are labeled, which is helpful, but distinctive styling would make replies even easier to spot while scrolling.

This change modifies the style sheet and templates to give replies a nested appearance for improved navigation of conversations in channels. Also included: instructions in the README for setting up a local environment and running a development server.

<img width="1300" alt="Screenshot 2023-11-19 at 16 42 16" src="https://github.com/hfaran/slack-export-viewer/assets/68482867/04fec539-3edb-49c5-a361-279dc8a56231">
