### PR TITLE
Ensure Compatibility with flask_frozen v1.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Werkzeug<3.0.0
 Flask<3.0.0
 markdown2
 emoji>=2.0.0,<3.0
-frozen-flask
+frozen-flask==1.0.1

--- a/slackviewer/freezer.py
+++ b/slackviewer/freezer.py
@@ -1,4 +1,5 @@
 from flask_frozen import Freezer
+from pathlib import Path
 
 class CustomFreezer(Freezer):
 
@@ -6,5 +7,10 @@ class CustomFreezer(Freezer):
 
     @property
     def root(self):
-        return u"{}".format(self.cf_output_dir)
-    
+        # Use the specified cf_output_dir if set
+        if self.cf_output_dir:
+            return Path(self.cf_output_dir)
+        # Otherwise, follow the default behavior of flask_frozen
+        else:
+            root = Path(self.app.root_path)
+            return root / self.app.config['FREEZER_DESTINATION']


### PR DESCRIPTION
This commit addresses an AttributeError encountered when using flask_frozen v1.0.1 with CustomFreezer class. Previously, the CustomFreezer's root property was returning a string representation of the cf_output_dir, which caused compatibility issues with the latest version of flask_frozen.

This update resolves the AttributeError ('str' object has no attribute 'mkdir') and ensures our CustomFreezer class works seamlessly with flask_frozen v1.0.1.

The error resolved by this change:
```
$ python3 app.py --channels test_channel -z test_dir --html-only -o output
Traceback (most recent call last):
  File "/Users/greymd/repos/hfaran/slack-export-viewer/app.py", line 6, in <module>
    main()
  File "/Users/greymd/repos/hfaran/slack-export-viewer/venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/greymd/repos/hfaran/slack-export-viewer/venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/greymd/repos/hfaran/slack-export-viewer/venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/greymd/repos/hfaran/slack-export-viewer/venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/greymd/repos/hfaran/slack-export-viewer/slackviewer/main.py", line 95, in main
    freezer.freeze()
  File "/Users/greymd/repos/hfaran/slack-export-viewer/venv/lib/python3.11/site-packages/flask_frozen/__init__.py", line 179, in freeze
    return set(page.url for page in self.freeze_yield())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/greymd/repos/hfaran/slack-export-viewer/venv/lib/python3.11/site-packages/flask_frozen/__init__.py", line 179, in <genexpr>
    return set(page.url for page in self.freeze_yield())
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/greymd/repos/hfaran/slack-export-viewer/venv/lib/python3.11/site-packages/flask_frozen/__init__.py", line 150, in freeze_yield
    self.root.mkdir(parents=True, exist_ok=True)
    ^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'mkdir'
```