### PR TITLE
Fixed extra } character in template

### DIFF
--- a/slackviewer/templates/util.html
+++ b/slackviewer/templates/util.html
@@ -38,7 +38,7 @@
                                 <div class="attachment-author">
                                     {% if not no_external_references %}
                                         <img src="{{attachment.author_icon}}" class="icon">
-                                    {% endif %}}
+                                    {% endif %}
                                     {%if attachment.author_link%}<a href="{{attachment.author_link}}">{%endif%}
                                     {{attachment.author_name}}
                                     {%if attachment.author_link%}</a><span class="print-only">({{attachment.author_link}})</span>{%endif%}


### PR DESCRIPTION
I kept seeing a } character on YouTube embeds/attachments and I found the culprit in this template file.

![image](https://github.com/user-attachments/assets/91209f32-862f-470a-97ed-0b1640470e40)
