### PR TITLE
remove extra whitespace making the messages view disappear in Firefox

### DIFF
--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -58,7 +58,7 @@
             {% endfor %}
         </ul>
     </div>
-    {% endif %}
+    {%- endif -%}
     <div class="messages">
         {% for message in messages %}
             {% if message.msg or message.files %}


### PR DESCRIPTION
the extra whitespace between the sidebar and the messages view causes the messages view to overflow to below the sidebar and hence be inaccessible because of `overflow: hidden` in the parent div.