### PR TITLE
support mattermost export format

### DIFF
--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -34,13 +34,7 @@ def send_file(name, attachment):
     if os.path.exists(try_path):
         return flask.send_file(try_path)
     try_path = os.path.join(app.data.path, "__uploads", attachment)
-    if os.path.exists(try_path):
-        return flask.send_file(try_path)
-    dirname = os.path.dirname(try_path)
-    target = os.path.basename(try_path)
-    for fn in os.listdir(dirname):
-        if fn.lower() == target:
-            return flask.send_file(os.path.join(dirname, fn))
+    return flask.send_file(try_path)
     
 
 @app.route("/channel/<name>/attachments/<attachment>")
@@ -48,9 +42,9 @@ def channel_name_attachment(name, attachment):
     return send_file(name, attachment)
 
 
-@app.route("/channel/<name>/attachments/<path>/<attachment>")
+@app.route("/channel/<name>/__uploads/<path>/<attachment>")
 def channel_name_path_attachment(name, path, attachment):
-    return send_file(name, os.path.join(path.split("-")[1], attachment))
+    return send_file(name, os.path.join(path, attachment))
 
 
 @app.route("/group/<name>/")
@@ -76,9 +70,9 @@ def group_name_attachment(name, attachment):
     return send_file(name, attachment)
 
 
-@app.route("/group/<name>/attachments/<path>/<attachment>")
+@app.route("/group/<name>/__uploads/<path>/<attachment>")
 def group_name_path_attachment(name, path, attachment):
-    return send_file(name, os.path.join(path.split("-")[1], attachment))
+    return send_file(name, os.path.join(path, attachment))
 
 
 @app.route("/dm/<id>/")
@@ -104,9 +98,9 @@ def dm_name_attachment(name, attachment):
     return send_file(name, attachment)
 
 
-@app.route("/dm/<name>/attachments/<path>/<attachment>")
+@app.route("/dm/<name>/__uploads/<path>/<attachment>")
 def dm_name_path_attachment(name, path, attachment):
-    return send_file(name, os.path.join(path.split("-")[1], attachment))
+    return send_file(name, os.path.join(path, attachment))
 
 
 @app.route("/mpim/<name>/")
@@ -132,9 +126,9 @@ def mpim_name_attachment(name, attachment):
     return send_file(name, attachment)
 
 
-@app.route("/mpim/<name>/attachments/<path>/<attachment>")
+@app.route("/mpim/<name>/__uploads/<path>/<attachment>")
 def mpim_name_path_attachment(name, path, attachment):
-    return send_file(name, os.path.join(path.split("-")[1], attachment))
+    return send_file(name, os.path.join(path, attachment))
 
 
 @app.route("/")

--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -9,14 +9,15 @@ app = flask.Flask(
     static_folder="static"
 )
 
+app.data = app.app_ctx_globals_class()
 
 @app.route("/channel/<name>/")
 def channel_name(name):
-    messages = flask._app_ctx_stack.channels[name]
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys()) if flask._app_ctx_stack.groups else {}
-    dm_users = list(flask._app_ctx_stack.dm_users)
-    mpim_users = list(flask._app_ctx_stack.mpim_users)
+    messages = app.data.channels[name]
+    channels = list(app.data.channels.keys())
+    groups = list(app.data.groups.keys()) if app.data.groups else {}
+    dm_users = list(app.data.dm_users)
+    mpim_users = list(app.data.mpim_users)
 
     return flask.render_template("viewer.html", messages=messages,
                                  name=name.format(name=name),
@@ -28,18 +29,37 @@ def channel_name(name):
                                  no_external_references=app.no_external_references)
 
 
+def send_file(name, attachment):
+    try_path = os.path.join(app.data.path, name, "attachments", attachment)
+    if os.path.exists(try_path):
+        return flask.send_file(try_path)
+    try_path = os.path.join(app.data.path, "__uploads", attachment)
+    if os.path.exists(try_path):
+        return flask.send_file(try_path)
+    dirname = os.path.dirname(try_path)
+    target = os.path.basename(try_path)
+    for fn in os.listdir(dirname):
+        if fn.lower() == target:
+            return flask.send_file(os.path.join(dirname, fn))
+    
+
 @app.route("/channel/<name>/attachments/<attachment>")
 def channel_name_attachment(name, attachment):
-    return flask.send_file(os.path.join(flask._app_ctx_stack.path, name, "attachments", attachment))
+    return send_file(name, attachment)
+
+
+@app.route("/channel/<name>/attachments/<path>/<attachment>")
+def channel_name_path_attachment(name, path, attachment):
+    return send_file(name, os.path.join(path.split("-")[1], attachment))
 
 
 @app.route("/group/<name>/")
 def group_name(name):
-    messages = flask._app_ctx_stack.groups[name]
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys())
-    dm_users = list(flask._app_ctx_stack.dm_users)
-    mpim_users = list(flask._app_ctx_stack.mpim_users)
+    messages = app.data.groups[name]
+    channels = list(app.data.channels.keys())
+    groups = list(app.data.groups.keys())
+    dm_users = list(app.data.dm_users)
+    mpim_users = list(app.data.mpim_users)
 
     return flask.render_template("viewer.html", messages=messages,
                                  name=name.format(name=name),
@@ -53,16 +73,21 @@ def group_name(name):
 
 @app.route("/group/<name>/attachments/<attachment>")
 def group_name_attachment(name, attachment):
-    return flask.send_file(os.path.join(flask._app_ctx_stack.path, name, "attachments", attachment))
+    return send_file(name, attachment)
+
+
+@app.route("/group/<name>/attachments/<path>/<attachment>")
+def group_name_path_attachment(name, path, attachment):
+    return send_file(name, os.path.join(path.split("-")[1], attachment))
 
 
 @app.route("/dm/<id>/")
 def dm_id(id):
-    messages = flask._app_ctx_stack.dms[id]
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys())
-    dm_users = list(flask._app_ctx_stack.dm_users)
-    mpim_users = list(flask._app_ctx_stack.mpim_users)
+    messages = app.data.dms[id]
+    channels = list(app.data.channels.keys())
+    groups = list(app.data.groups.keys())
+    dm_users = list(app.data.dm_users)
+    mpim_users = list(app.data.mpim_users)
 
     return flask.render_template("viewer.html", messages=messages,
                                  id=id.format(id=id),
@@ -76,16 +101,21 @@ def dm_id(id):
 
 @app.route("/dm/<name>/attachments/<attachment>")
 def dm_name_attachment(name, attachment):
-    return flask.send_file(os.path.join(flask._app_ctx_stack.path, name, "attachments", attachment))
+    return send_file(name, attachment)
+
+
+@app.route("/dm/<name>/attachments/<path>/<attachment>")
+def dm_name_path_attachment(name, path, attachment):
+    return send_file(name, os.path.join(path.split("-")[1], attachment))
 
 
 @app.route("/mpim/<name>/")
 def mpim_name(name):
-    messages = flask._app_ctx_stack.mpims.get(name, list())
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys())
-    dm_users = list(flask._app_ctx_stack.dm_users)
-    mpim_users = list(flask._app_ctx_stack.mpim_users)
+    messages = app.data.mpims.get(name, list())
+    channels = list(app.data.channels.keys())
+    groups = list(app.data.groups.keys())
+    dm_users = list(app.data.dm_users)
+    mpim_users = list(app.data.mpim_users)
 
     return flask.render_template("viewer.html", messages=messages,
                                  name=name.format(name=name),
@@ -99,25 +129,30 @@ def mpim_name(name):
 
 @app.route("/mpim/<name>/attachments/<attachment>")
 def mpim_name_attachment(name, attachment):
-    return flask.send_file(os.path.join(flask._app_ctx_stack.path, name, "attachments", attachment))
+    return send_file(name, attachment)
+
+
+@app.route("/mpim/<name>/attachments/<path>/<attachment>")
+def mpim_name_path_attachment(name, path, attachment):
+    return send_file(name, os.path.join(path.split("-")[1], attachment))
 
 
 @app.route("/")
 def index():
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys())
-    dms = list(flask._app_ctx_stack.dms.keys())
-    mpims = list(flask._app_ctx_stack.mpims.keys())
+    channels = list(app.data.channels.keys())
+    groups = list(app.data.groups.keys())
+    dms = list(app.data.dms.keys())
+    mpims = list(app.data.mpims.keys())
     if channels:
         if "general" in channels:
-            return channel_name("general")
+            return flask.redirect(flask.url_for(channel_name.__name__, name="general"))
         else:
-            return channel_name(channels[0])
+            return flask.redirect(flask.url_for(channel_name.__name__, name=channels[0]))
     elif groups:
-        return group_name(groups[0])
+        return flask.redirect(flask.url_for(group_name.__name__, name=groups[0]))
     elif dms:
-        return dm_id(dms[0])
+        return flask.redirect(flask.url_for(dm_id.__name__, id=dms[0]))
     elif mpims:
-        return mpim_name(mpims[0])
+        return flask.redirect(flask.url_for(mpim_name.__name__, name=mpims[0]))
     else:
         return "No content was found in your export that we could render."

--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -21,14 +21,13 @@ def configure_app(app, archive, channels, no_sidebar, no_external_references, de
     path = extract_archive(archive)
     reader = Reader(path)
 
-    top = flask._app_ctx_stack
-    top.path = path
-    top.channels = reader.compile_channels(channels)
-    top.groups = reader.compile_groups()
-    top.dms = reader.compile_dm_messages()
-    top.dm_users = reader.compile_dm_users()
-    top.mpims = reader.compile_mpim_messages()
-    top.mpim_users = reader.compile_mpim_users()
+    app.data.path = path
+    app.data.channels = reader.compile_channels(channels)
+    app.data.groups = reader.compile_groups()
+    app.data.dms = reader.compile_dm_messages()
+    app.data.dm_users = reader.compile_dm_users()
+    app.data.mpims = reader.compile_mpim_messages()
+    app.data.mpim_users = reader.compile_mpim_users()
 
 @click.command()
 @click.option('-p', '--port', default=envvar('SEV_PORT', '5000'),
@@ -90,7 +89,7 @@ def main(
         # This tells freezer about the channel URLs
         @freezer.register_generator
         def channel_name():
-            for channel in flask._app_ctx_stack.channels:
+            for channel in app.data.channels:
                 yield {"name": channel}
 
         freezer.freeze()

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import datetime
 import logging
 import emoji
+import os
 
 class Message(object):
 
@@ -184,7 +185,7 @@ class LinkAttachment(object):
             ret = self._raw.get("url_private")
         prefix_to_remove = "https://files.slack.com/files-pri/"
         if ret.startswith(prefix_to_remove):
-            ret = "attachments/" + ret[len(prefix_to_remove):]
+            ret = "__uploads/" + os.path.dirname(ret[len(prefix_to_remove):]).split("-")[1] + "/" + self._raw["name"]
         return ret
 
     @property

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -177,10 +177,15 @@ class LinkAttachment(object):
 
     @property
     def link(self):
+        ret = None
         if "from_url" in self._raw:
-            return self._raw["from_url"]
+            ret = self._raw["from_url"]
         else:
-            return self._raw.get("url_private")
+            ret = self._raw.get("url_private")
+        prefix_to_remove = "https://files.slack.com/files-pri/"
+        if ret.startswith(prefix_to_remove):
+            ret = "attachments/" + ret[len(prefix_to_remove):]
+        return ret
 
     @property
     def fields(self):


### PR DESCRIPTION
To support the attachments in the mattermost output type, it was necessary to rewrite the image links to reference the following path in the ZIP file:
```
https://files.slack.com/files-pri/T0ABC1DEF-F0123A4B56C/image.jpg -> __uploads/F0123A4B56C/image.jpg
```
Moreover, the downloaded file might have uppercase letters in the name but in the link it was converted to lowercase. Hence, there was need to list the directory containing the file and see if there was a file, e.g. __uploads/F0123A4B56C/Image.JPG, whose name after conversion to lowercase matched the link.