### PR TITLE
Improve thread representation

### DIFF
--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -12,6 +12,10 @@ class Message(object):
     def __init__(self, formatter, message):
         self._formatter = formatter
         self._message = message
+        # default is False, we update it later if its a thread message
+        self.is_thread_msg = False
+        # used only with --since flag. Default to True, will update in the function
+        self.is_recent_msg = True
 
     def __repr__(self):
         message = self._message.get("text")

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -174,6 +174,10 @@ body {
     max-width: 10px;
 }
 
+.message-container .old-message {
+    color: #999999;
+}
+
 .channel_join .msg, .channel_topic .msg,
 .bot_add .msg, .app_conversation_join .msg {
     font-style: italic;

--- a/slackviewer/templates/util.html
+++ b/slackviewer/templates/util.html
@@ -11,18 +11,21 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro render_message(message, preview_size=None, no_external_references=False, reply=False) -%}
-    <div class="message-container{%if message.subtype %} {{message.subtype}} {% elif reply.subtype %} {{reply.subtype}} {%endif%}">
+{% macro render_message(message, preview_size=None, no_external_references=False) -%}
+    <div class="message-container{%if message.subtype %} {{message.subtype}} {%endif%}">
         <div id="{{ message.id }}">
-            {% if not no_external_references and not reply %}
-                {% if message.img %}<img src="{{ message.img }}" class="user_icon" />{%else%}<div class="user_icon"></div>{%endif%}
-            {% elif not no_external_references and reply %}
-                {% if message.img %}<img src="{{ message.img }}" class="user_icon_reply" />{%else%}<div class="user_icon_reply"></div>{%endif%}
+            {% if not message.is_recent_msg %}
+                <div class="old-message">
             {% endif %}
-            {% if not reply %}
+            {% if not message.is_thread_msg %}
                 <div class="message">
             {% else %}
                 <div class="reply">
+            {% endif %}
+            {% if not no_external_references and not message.is_thread_msg %}
+                {% if message.img %}<img src="{{ message.img }}" class="user_icon" />{%else%}<div class="user_icon"></div>{%endif%}
+            {% elif not no_external_references and message.is_thread_msg %}
+                {% if message.img %}<img src="{{ message.img }}" class="user_icon_reply" />{%else%}<div class="user_icon_reply"></div>{%endif%}
             {% endif %}
                 <div class="username">{{ message.username }}
                     {%if message.user.email%} <span class="print-only user-email">({{message.user.email}})</span>{%endif%}

--- a/slackviewer/templates/viewer.html
+++ b/slackviewer/templates/viewer.html
@@ -62,11 +62,7 @@
     <div class="messages">
         {% for message in messages %}
             {% if message.msg or message.files %}
-                {% if message.msg and "Thread Reply:" in message.msg %}
-                    {{render_message(message, None, no_external_references, reply=True)}}
-                {% else %}
-                    {{render_message(message, None, no_external_references, reply=False)}}
-                {% endif %}
+                {{render_message(message, None, no_external_references)}}
             {% endif %}
         {% endfor %}
     </div>


### PR DESCRIPTION
This PR has the following changes mainly around thread improvement

- Thread messages have two new settings:
   - is a message a thread message
   - is the message a recent message if `--since` is used
- Thread messages get automatic formatting without additional check requirements in the html template
- Icons of thread messages are now also indented
- If `--since` is used, old messages in threads are greyed out.
