### PR TITLE
Add permalink metadata to message object

### DIFF
--- a/slackviewer/formatter.py
+++ b/slackviewer/formatter.py
@@ -19,7 +19,7 @@ class SlackFormatter(object):
     # Class-level constants for precompilation of frequently-reused regular expressions
     # URL detection relies on http://stackoverflow.com/a/1547940/1798683
     _LINK_PAT = re.compile(r"<(https|http|mailto):[A-Za-z0-9_\.\-\/\?\,\=\#\:\@]+\|[^>]+>")
-    _MENTION_PAT = re.compile(r"<((?:#C|@[UB])\w+)(?:\|([A-Za-z0-9.-_]+))?>")
+    _MENTION_PAT = re.compile(r"<((?:#C|@[UB])\w+)(?:\|([A-Za-z0-9.-_]*))?>")
     _HASHTAG_PAT = re.compile(r"(^| )#[A-Za-z][\w\.\-\_]+( |$)")
 
     def __init__(self, USER_DATA, CHANNEL_DATA):

--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -9,13 +9,17 @@ class Message(object):
 
     _DEFAULT_USER_ICON_SIZE = 72
 
-    def __init__(self, formatter, message):
+    def __init__(self, formatter, message, channel_id, slack_name):
         self._formatter = formatter
         self._message = message
         # default is False, we update it later if its a thread message
         self.is_thread_msg = False
         # used only with --since flag. Default to True, will update in the function
         self.is_recent_msg = True
+        # Channel id is not part of self._message - at least not with slackdump
+        self.channel_id = channel_id
+        # slack name that is in the url https://<slackname>.slack.com
+        self.slack_name = slack_name
 
     def __repr__(self):
         message = self._message.get("text")
@@ -126,6 +130,13 @@ class Message(object):
     @property
     def subtype(self):
         return self._message.get("subtype")
+
+    @property
+    def permalink(self):
+        permalink = f"https://{self.slack_name}.slack.com/archives/{self.channel_id}/p{self._message['ts'].replace('.','')}"
+        if "thread_ts" in self._message:
+            permalink += f"?thread_ts={self._message['thread_ts']}&cid={self.channel_id}"
+        return permalink
 
 
 class LinkAttachment():

--- a/slackviewer/templates/example_template_single_export.html
+++ b/slackviewer/templates/example_template_single_export.html
@@ -31,6 +31,7 @@
                     {%if message.user.email%} <span class="print-only user-email">({{message.user.email}})</span>{%endif%}
                 </div>
                 <a href="#{{ message.id}}"><div class="time">{{ message.time }}</div></a>
+                <a href="{{ message.permalink}}"><div class="permalink">permalink</div></a>
                 <div class="msg">
                     {{ message.msg|safe }}
                     {% for attachment in message.attachments -%}


### PR DESCRIPTION
Add permalink option to message object.  It's not used in this PR since I do not want to commit a modified template.

While its currently not used by `templates/util.html`, it can be used when providing your own template. Example has been added to the existing template.