### PR TITLE
Avoid making --- in the message to a h2

### DIFF
--- a/slackviewer/formatter.py
+++ b/slackviewer/formatter.py
@@ -73,6 +73,8 @@ class SlackFormatter(object):
         if process_markdown:
             # Handle bold (convert * * to ** **)
             message = re.sub(r'\*', "**", message)
+            # Make sure --- won't wrap the previous line with <h2>
+            message = re.sub(r'---', "\\-\\-\\-", message)
 
             message = markdown2.markdown(
                 message,


### PR DESCRIPTION
tripple dashes can get the prior line wrapped into `<h2>`. Avoid this by escaping the first three dashes. Additional don't make a difference.