### PR TITLE
Fix app not running when using --no-browser flag

### DIFF
--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -108,8 +108,9 @@ def main(
             webbrowser.open("file:///{}/index.html"
                             .format(os.path.abspath(output_dir)))
 
-    elif not no_browser and not test:
-        webbrowser.open("http://{}:{}".format(ip, port))
+    elif not test:
+        if not no_browser:
+            webbrowser.open("http://{}:{}".format(ip, port))
         app.run(
             host=ip,
             port=port


### PR DESCRIPTION
Fix issue reported in https://github.com/hfaran/slack-export-viewer/issues/201

`slack-export-viewer -z . --no-browser --debug` does not open a browser due to the `--no-browser` flag.