### PR TITLE
Raise proper error if archive option isn't provided

### DIFF
--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -46,8 +46,8 @@ def configure_app(app, archive, channels, config):
 @click.command()
 @click.option('-p', '--port', default=envvar('SEV_PORT', '5000'),
               type=click.INT, help="Host port to serve your content on")
-@click.option("-z", "--archive", type=click.Path(), required=True,
-              default=envvar('SEV_ARCHIVE', ''),
+@click.option("-z", "--archive", type=click.Path(exists=True), required=True,
+              envvar='SEV_ARCHIVE',
               help="Path to your Slack export archive (.zip file or directory)")
 @click.option('-I', '--ip', default=envvar('SEV_IP', 'localhost'),
               type=click.STRING, help="Host IP to serve your content on")
@@ -75,7 +75,6 @@ def configure_app(app, archive, channels, config):
 @click.option("--since", default=None, type=click.DateTime(formats=["%Y-%m-%d"]),
               help="Only show messages since this date.")
 @click.option('--skip-dms', is_flag=True, default=False, help="Hide direct messages")
-
 def main(
     port,
     archive,


### PR DESCRIPTION
Reported in https://github.com/hfaran/slack-export-viewer/issues/194

The option is currently set to default to `""`. This way if there is no folder or file provided, and issues is raised with an entire stacktrace.

PR hands over  to click if
- the environment variable is set -- or if the the flag is used
- the file/folder exists that was provided through flag or environment variable

Example output
```
% slack-export-viewer
Usage: slack-export-viewer [OPTIONS]
Try 'slack-export-viewer --help' for help.

Error: Missing option '-z' / '--archive'.
```

invalid file/folder
```
% slack-export-viewer -z invalid
Usage: slack-export-viewer [OPTIONS]
Try 'slack-export-viewer --help' for help.

Error: Invalid value for '-z' / '--archive': Path 'invalid' does not exist.
```