### PR TITLE
Add option to skip messages when a user joins/leaves a channel

### DIFF
--- a/slackviewer/archive.py
+++ b/slackviewer/archive.py
@@ -60,8 +60,11 @@ def extract_archive(filepath):
         #  if there are new features added
         extra=to_bytes(slackviewer.__version__)
     )
+    # use the zip file name as full path. This allows then slack name to be
+    # extracted from the path later in reader.py when creating direct slack URLs
+    slack_name = splitext(basename(filepath))[0]
 
-    extracted_path = os.path.join(SLACKVIEWER_TEMP_PATH, archive_sha)
+    extracted_path = os.path.join(SLACKVIEWER_TEMP_PATH, archive_sha, slack_name)
 
     if os.path.exists(extracted_path):
         print("{} already exists".format(extracted_path))
@@ -73,8 +76,7 @@ def extract_archive(filepath):
                 print(info.filename)
                 info.filename = info.filename.encode("cp437").decode("utf-8")
                 print(info.filename)
-                zip.extract(info,path=extracted_path)
-
+                zip.extract(info, path=extracted_path)
 
         print("{} extracted to {}".format(filepath, extracted_path))
 
@@ -112,27 +114,3 @@ def create_archive_info(filepath, extracted_path, archive_sha=None):
         s = json.dumps(archive_info, ensure_ascii=False)
         s = to_unicode(s)
         f.write(s)
-
-
-def get_export_info(archive_name):
-    """
-    Given a file or directory, extract it and return information that will be used in
-    an export printout: the basename of the file, the name stripped of its extension, and
-    our best guess (based on Slack's current naming convention) of the name of the
-    workspace that this is an export of.
-    """
-    extracted_path = extract_archive(archive_name)
-    base_filename = basename(archive_name)
-    (noext_filename, _) = splitext(base_filename)
-    workspace_name = base_filename
-    # In case the archive is a zip file
-    if not os.path.isdir(extracted_path):
-        # Typical extract name: "My Friends and Family Slack export Jul 21 2018 - Sep 06 2018"
-        # If that's not the format, we will just fall back to the extension-free filename.
-        (workspace_name, _) = noext_filename.split(" Slack export ", 1)
-    return {
-        "readable_path": extracted_path,
-        "basename": base_filename,
-        "stripped_name": noext_filename,
-        "workspace_name": workspace_name,
-    }

--- a/slackviewer/cli.py
+++ b/slackviewer/cli.py
@@ -5,10 +5,11 @@ import os.path
 
 from datetime import datetime
 
-from slackviewer.constants import SLACKVIEWER_TEMP_PATH
-from slackviewer.utils.click import envvar, flag_ennvar
-from slackviewer.reader import Reader
 from jinja2 import Environment, PackageLoader
+from slackviewer.config import Config
+from slackviewer.constants import SLACKVIEWER_TEMP_PATH
+from slackviewer.reader import Reader
+from slackviewer.utils.click import envvar, flag_ennvar
 
 
 @click.group()
@@ -40,13 +41,13 @@ def clean(wet):
 @click.option("--template", default=None, type=click.File('r'), help="Custom single file export template")
 @click.argument('archive')
 def export(**kwargs):
-    config = kwargs
+    config = Config(kwargs)
 
     css = pkgutil.get_data('slackviewer', 'static/viewer.css').decode('utf-8')
 
     tmpl = Environment(loader=PackageLoader('slackviewer')).get_template("export_single.html")
-    if config["template"]:
-        tmpl = Environment(loader=PackageLoader('slackviewer')).from_string(config["template"].read())
+    if config.template:
+        tmpl = Environment(loader=PackageLoader('slackviewer')).from_string(config.template.read())
     r = Reader(config)
     channel_list = sorted(
         [{"channel_name": k, "messages": v} for (k, v) in r.compile_channels().items()],
@@ -55,7 +56,7 @@ def export(**kwargs):
 
     dm_list = []
     mpims = []
-    if config["show_dms"]:
+    if config.show_dms:
         #
         # Direct DMs
         dm_list = r.compile_dm_messages()
@@ -86,7 +87,7 @@ def export(**kwargs):
         css=css,
         generated_on=datetime.now(),
         workspace_name=r.slack_name(),
-        source_file=os.path.basename(config["archive"]),
+        source_file=os.path.basename(config.archive),
         channels=channel_list,
         dms=dm_list,
         mpims=mpims,

--- a/slackviewer/cli.py
+++ b/slackviewer/cli.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from slackviewer.constants import SLACKVIEWER_TEMP_PATH
 from slackviewer.utils.click import envvar, flag_ennvar
 from slackviewer.reader import Reader
-from slackviewer.archive import get_export_info
 from jinja2 import Environment, PackageLoader
 
 
@@ -37,21 +36,18 @@ def clean(wet):
 @click.option('--show-dms', is_flag=True, default=False, help="Show direct messages")
 @click.option("--since", default=None, type=click.DateTime(formats=["%Y-%m-%d"]),
               help="Only show messages since this date.")
+@click.option('--skip-channel-member-change', is_flag=True, default=False, envvar='SKIP_CHANNEL_MEMBER_CHANGE', help="Hide channel join/leave messages")
 @click.option("--template", default=None, type=click.File('r'), help="Custom single file export template")
-@click.argument('archive_dir')
+@click.argument('archive')
+def export(**kwargs):
+    config = kwargs
 
-def export(archive_dir, debug, since, template, show_dms):
     css = pkgutil.get_data('slackviewer', 'static/viewer.css').decode('utf-8')
 
     tmpl = Environment(loader=PackageLoader('slackviewer')).get_template("export_single.html")
-    if template:
-        tmpl = Environment(loader=PackageLoader('slackviewer')).from_string(template.read())
-    export_file_info = get_export_info(archive_dir)
-    config = {
-        "debug": debug,
-        "since": since,
-    }
-    r = Reader(export_file_info["readable_path"], config)
+    if config["template"]:
+        tmpl = Environment(loader=PackageLoader('slackviewer')).from_string(config["template"].read())
+    r = Reader(config)
     channel_list = sorted(
         [{"channel_name": k, "messages": v} for (k, v) in r.compile_channels().items()],
         key=lambda d: d["channel_name"]
@@ -59,10 +55,10 @@ def export(archive_dir, debug, since, template, show_dms):
 
     dm_list = []
     mpims = []
-    if show_dms:
+    if config["show_dms"]:
         #
         # Direct DMs
-        dm_list =  r.compile_dm_messages()
+        dm_list = r.compile_dm_messages()
         dm_users = r.compile_dm_users()
 
         # make list better lookupable. Also hide own user in 1:1 DMs
@@ -89,13 +85,14 @@ def export(archive_dir, debug, since, template, show_dms):
     html = tmpl.render(
         css=css,
         generated_on=datetime.now(),
-        workspace_name=export_file_info["workspace_name"],
-        source_file=export_file_info["basename"],
+        workspace_name=r.slack_name(),
+        source_file=os.path.basename(config["archive"]),
         channels=channel_list,
         dms=dm_list,
         mpims=mpims,
     )
-    with open(export_file_info['stripped_name'] + '.html', 'wb') as outfile:
+    filename = f"{r.slack_name()}.html"
+    with open(filename, 'wb') as outfile:
         outfile.write(html.encode('utf-8'))
 
-    print("Exported to {}.html".format(export_file_info['stripped_name']))
+    print(f"Exported to {filename}")

--- a/slackviewer/config.py
+++ b/slackviewer/config.py
@@ -1,0 +1,49 @@
+import logging
+import sys
+
+class Config(object):
+    """
+    Config object to to retreive all config input and make sure all expected
+    variables either or have a None value
+    """
+    def __init__(self, config):
+        self._config = config
+
+        # FYI: click verifies most types already as well as if files/dirs exist
+
+        # Args used by both webserver and cli
+        self.debug = config.get("debug")
+        self.since = config.get("since")
+        self.skip_channel_member_change = config.get("skip_channel_member_change")
+        self.archive = config.get("archive")
+
+        # CLI only
+        self.template = config.get("template")
+        # Another branch exists already to unify them
+        self.show_dms = config.get("show_dms")
+
+        # webserver only setting
+        self.ip = config.get("ip")
+        self.port = config.get("port")
+        self.no_browser = config.get("no_browser")
+        self.channels = config.get("channels")
+        self.no_sidebar = config.get("no_sidebar")
+        self.no_external_references = config.get("no_external_references")
+        self.test = config.get("test")
+        self.debug = config.get("debug")
+        self.output_dir = config.get("output_dir")
+        self.html_only = config.get("html_only")
+        # separate code exists to combine them. PR after this one
+        self.skip_dms = config.get("skip_dms")
+
+        self.sanity_check()
+
+    def sanity_check(self):
+        """Make sure all variables exist"""
+        for key in self._config:
+            try:
+                # check if self.<key> exists
+                getattr(self, key)
+            except AttributeError:
+                logging.fatal(f"Configuration '{key}' is not implemented")
+                sys.exit(1)

--- a/slackviewer/reader.py
+++ b/slackviewer/reader.py
@@ -20,8 +20,8 @@ class Reader(object):
 
     def __init__(self, config):
         self._config = config
-        self._PATH = extract_archive(config["archive"])
-        self._since = config["since"]
+        self._PATH = extract_archive(config.archive)
+        self._since = config.since
         # slack name that is in the url https://<slackname>.slack.com
         self._slack_name = self._get_slack_name()
         # TODO: Make sure this works
@@ -248,7 +248,7 @@ class Reader(object):
 
             for location, message in enumerate(channel_data[channel_name]):
                 # remove "<user> joined/left <channel>" message
-                if self._config['skip_channel_member_change'] and message._message.get('subtype') in ['channel_join', 'channel_leave']:
+                if self._config.skip_channel_member_change and message._message.get('subtype') in ['channel_join', 'channel_leave']:
                     items_to_remove.append(location)
                     continue
 


### PR DESCRIPTION
Add feature flag to hide messages when a user joins/leaves a channel.

This PR also changes how config options handed over by click. Instead of having to add each new arg in a list, it automatically hands them over in an config dict. As result the way how these configs are set had to be changes where they are used.

This PR also moves the zip file extraction to the Reader class. The reason is that cli.py and main.py had separate extract options. At the same time, cli.py used the unzip function to generate the slack name, which also needs to be computed in the Reader class itself.


PR resolves also https://github.com/hfaran/slack-export-viewer/issues/191