### PR TITLE
Bugfix: revert default value for DM's in app

### DIFF
--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -92,7 +92,7 @@ def configure_app(app, config):
     Only show messages since this date.
     Environment var: SEV_SINCE (default: None)
     """)
-@click.option('--show-dms/--no-show-dms', default=False, envvar='SEV_SHOW_DMS', help="""\b
+@click.option('--show-dms/--no-show-dms', default=True, envvar='SEV_SHOW_DMS', help="""\b
     Show/Hide direct messages
     Environment var: SEV_SHOW_DMS (default: false)
     """)


### PR DESCRIPTION
Bugfix: documentation update made me copy the default from the cli to the app.

This reverts the behavior and DMs are shown by default (currently it requires `python3 app.py -z <export> --show-dms`