### PR TITLE
Stylefix

### DIFF
--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -71,7 +71,6 @@ body {
 .message-container {
     clear: left;
     min-height: 56px;
-    max-width: 98%;
     margin-bottom: 4px;
 }
 
@@ -134,14 +133,13 @@ body {
 .message-container .reply {
     vertical-align: top;
     line-height: 1;
-    width: calc(100% - 3em);
+    width: calc(97% - 3em);
     margin-left: 60px;
     margin-bottom: 10px;
 }
 
 .message-container .msg p {
     white-space: pre-wrap;
-    margin-left: 56px;
     margin-top: 10px;
     margin-bottom: 10px;
 }
@@ -154,11 +152,13 @@ body {
 .message-container .message .msg {
     line-height: 1.5;
     padding-top: 2px;
+    margin-left: 60px;
 }
 
 .message-container .reply .msg {
     line-height: 1.5;
     margin-top: -3px;
+    margin-left: 56px;
 }
 
 .message-container .message .msg a {

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -72,6 +72,7 @@ body {
     clear: left;
     min-height: 56px;
     max-width: 98%;
+    margin-bottom: 4px;
 }
 
 .message-container:first-child {
@@ -127,17 +128,19 @@ body {
     vertical-align: top;
     line-height: 1;
     width: calc(100% - 3em);
+    margin-bottom: -10px;
 }
 
 .message-container .reply {
     vertical-align: top;
     line-height: 1;
     width: calc(100% - 3em);
-    margin-left: 80px;
+    margin-left: 60px;
 }
 
 .message-container .msg p {
     white-space: pre-wrap;
+    margin-left: 56px;
 }
 
 .message-container .msg pre {
@@ -147,10 +150,12 @@ body {
 
 .message-container .message .msg {
     line-height: 1.5;
+    margin-top: -4px;
 }
 
 .message-container .reply .msg {
     line-height: 1.5;
+    margin-top: -8px;
 }
 
 .message-container .message .msg a {
@@ -164,7 +169,7 @@ body {
 .message-container .message-attachment {
     padding-left: 20px;
     border-left: 12px gray solid;
-    margin-left: 18px;
+    margin-left: 60px;
     margin-bottom: 20px;
     overflow-wrap: anywhere;
 }
@@ -182,8 +187,9 @@ body {
 }
 
 .message-reaction {
-  transform: scale(150%);
-  margin: 20px 20%;
+transform: scale(115%);
+margin: 0 55px 20px;
+transform-origin: left;
 }
 
 blockquote {

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -128,7 +128,7 @@ body {
     vertical-align: top;
     line-height: 1;
     width: calc(100% - 3em);
-    margin-bottom: -10px;
+    margin-bottom: 10px;
 }
 
 .message-container .reply {
@@ -136,11 +136,14 @@ body {
     line-height: 1;
     width: calc(100% - 3em);
     margin-left: 60px;
+    margin-bottom: 10px;
 }
 
 .message-container .msg p {
     white-space: pre-wrap;
     margin-left: 56px;
+    margin-top: 10px;
+    margin-bottom: 10px;
 }
 
 .message-container .msg pre {
@@ -150,12 +153,12 @@ body {
 
 .message-container .message .msg {
     line-height: 1.5;
-    margin-top: -4px;
+    padding-top: 2px;
 }
 
 .message-container .reply .msg {
     line-height: 1.5;
-    margin-top: -8px;
+    margin-top: -3px;
 }
 
 .message-container .message .msg a {
@@ -170,7 +173,7 @@ body {
     padding-left: 20px;
     border-left: 12px gray solid;
     margin-left: 60px;
-    margin-bottom: 20px;
+    margin-bottom: 6px;
     overflow-wrap: anywhere;
 }
 
@@ -187,20 +190,22 @@ body {
 }
 
 .message-reaction {
-transform: scale(115%);
-margin: 0 55px 20px;
-transform-origin: left;
+    transform: scale(115%);
+    margin: 0 55px 20px;
+    transform-origin: left;
 }
 
 blockquote {
-  padding-left: 20px;
-  border-left: 12px gray solid;
-  margin-left: 60px;
+    padding-left: 20px;
+    border-left: 12px gray solid;
+    margin-left: 60px;
+    margin-top: 10px;
+    margin-bottom: 10px;
 }
 
 ul, ol {
-  padding-left: 20px;
-  margin-left: 60px;
+    padding-left: 20px;
+    margin-left: 60px;
 }
 
 .channel_join .msg, .channel_topic .msg,

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -71,6 +71,7 @@ body {
 .message-container {
     clear: left;
     min-height: 56px;
+    max-width: 98%;
 }
 
 .message-container:first-child {
@@ -83,8 +84,8 @@ body {
 
 .message-container .user_icon {
     background-color: rgb(248, 244, 240);
-    width: 36px;
-    height: 36px;
+    width: 50px;
+    height: 50px;
     border-radius: 0.2em;
     display: inline-block;
     vertical-align: top;
@@ -94,13 +95,13 @@ body {
 
 .message-container .user_icon_reply {
     background-color: rgb(248, 244, 240);
-    width: 36px;
-    height: 36px;
+    width: 45px;
+    height: 45px;
     border-radius: 0.2em;
     display: inline-block;
     vertical-align: top;
     margin-right: 0.65em;
-    margin-left: 40px;
+    margin-left: 0px;
     float: left;
 }
 
@@ -161,8 +162,10 @@ body {
 }
 
 .message-container .message-attachment {
-    padding-left: 5px;
-    border-left: 2px gray solid;
+    padding-left: 20px;
+    border-left: 12px gray solid;
+    margin-left: 18px;
+    margin-bottom: 20px;
     overflow-wrap: anywhere;
 }
 
@@ -176,6 +179,22 @@ body {
 
 .message-container .old-message {
     color: #999999;
+}
+
+.message-reaction {
+  transform: scale(150%);
+  margin: 20px 20%;
+}
+
+blockquote {
+  padding-left: 20px;
+  border-left: 12px gray solid;
+  margin-left: 60px;
+}
+
+ul, ol {
+  padding-left: 20px;
+  margin-left: 60px;
 }
 
 .channel_join .msg, .channel_topic .msg,
@@ -240,6 +259,6 @@ a:hover {
 }
 
 img.preview {
-    max-width: 100%;
+    max-width: 50%;
     height: auto;
 }

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -66,6 +66,7 @@ body {
     padding-left: 20px;
     padding-right: 20px;
     overflow-y: scroll;
+    overflow-x: hidden;
 }
 
 .message-container {

--- a/slackviewer/static/viewer.css
+++ b/slackviewer/static/viewer.css
@@ -101,7 +101,6 @@ body {
     display: inline-block;
     vertical-align: top;
     margin-right: 0.65em;
-    margin-left: 0px;
     float: left;
 }
 


### PR DESCRIPTION
Improved the indentation of comment replies as well as text quote blocks
Widened the attachment quote bar to match
Limited images to only appear at max 50% of the page
Enlarged user icons a bit, let me know if that is not desired

Added blockquote, ol and li styles which correspond to the addition of these elements on my other PR #225 which uses these when constructing messages out of block elements.

Hid the overflow of the .messages element to prevent unnecessary scroll action, please let me know if this is important to preserve for someone else's use case.