### PR TITLE
Revert PR #166

### DIFF
--- a/slackviewer/archive.py
+++ b/slackviewer/archive.py
@@ -72,11 +72,7 @@ def extract_archive(filepath):
         # Extract zip
         with zipfile.ZipFile(filepath) as zip:
             print("{} extracting to {}...".format(filepath, extracted_path))
-            for info in zip.infolist():
-                print(info.filename)
-                info.filename = info.filename.encode("cp437").decode("utf-8")
-                print(info.filename)
-                zip.extract(info, path=extracted_path)
+            zip.extractall(path=extracted_path)
 
         print("{} extracted to {}".format(filepath, extracted_path))
 


### PR DESCRIPTION
That PR was round-tripping filenames through encoding cp437, which failed with filenames containing characters not supported by that encoding.