### PR TITLE
Fix rich text naked urls

### DIFF
--- a/slackviewer/message.py
+++ b/slackviewer/message.py
@@ -100,32 +100,27 @@ class Message(object):
             text = self._message.get("text", "")
             if not text or text.strip() == "":
                 text = "[ MESSAGE TEXT EMPTY ]"
-
         return self._formatter.render_text(text)
-
 
     def _generate_blocks_text(self, blocks):
         """Build a message together from various message["blocks"]"""
         text = ""
         for block in blocks:
-            if block["type"] in ["rich_text", "rich_text_quote"]:
+            if block["type"] == "image":
+                text += self._format_block_type(block, block["type"])
+            elif block["type"] in ["rich_text", "rich_text_quote"]:
                 for element in block["elements"]:
                     text += self._format_rich_text_element(element)
-
             elif "fields" in block:
                 for field in block["fields"]:
                     text += self._format_block_type(field, block["type"])
-
             elif "elements" in block:
                 for element in block["elements"]:
                     text += self._format_block_type(element, block["type"])
-
             elif "type" in block and block["type"] == "divider":
                 text += "---\n"
-
             else:
                 logging.warning(f"Unknown block type: {block}")
-
         return text
 
     def _format_rich_text_element(self, element):
@@ -153,9 +148,12 @@ class Message(object):
             return text
 
         elif element["type"] == "link":
-            text = element.get('text', element['url']).replace("_", "&#95;")
-            return f"<a href='{element['url']}'>{text}</a>"
+            text = element.get('text', "")
+            if not text:
+                text = element['url'].replace("\\/", "/")
 
+            text = text.replace("_", "&#95;")
+            return f"<a href='{element['url']}'>{text}</a>"
 
         elif element["type"] == "user":
             user = self._formatter.find_user(self.user_message(element['user_id']))
@@ -203,9 +201,6 @@ class Message(object):
 
         logging.warning(f"Unsupported rich text element type '{element['type']}' for {element}")
         return ""
-
-
-
 
     def _format_block_type(self, text_obj, b_type):
         """Format the text based on the block type"""
@@ -258,30 +253,6 @@ class Message(object):
         else:
             logging.warning(f"Unsupported block type '{b_type}' for {text_obj}")
             return f"unsupported_block({b_type}: {text_obj}\n\n)"
-
-
-
-    def _generate_blocks_text(self, blocks):
-        """Build a message together from various message["blocks"]"""
-        text = ""
-        for block in blocks:
-            if block["type"] == "image":
-                text += self._format_block_type(block, block["type"])
-            elif block["type"] in ["rich_text", "rich_text_quote"]:
-                for element in block["elements"]:
-                    text += self._format_rich_text_element(element)
-            elif "fields" in block:
-                for field in block["fields"]:
-                    text += self._format_block_type(field, block["type"])
-            elif "elements" in block:
-                for element in block["elements"]:
-                    text += self._format_block_type(element, block["type"])
-            elif "type" in block and block["type"] == "divider":
-                text += "---\n"
-            else:
-                logging.warning(f"Unknown block type: {block}")
-        return text
-
 
 
     def user_message(self, user_id):


### PR DESCRIPTION
This corrects an issue where the way blocks were used to build messages did not display links unless they were hyperlinked text. If they were naked urls, there was no visible link text.

The naked url will now show.