### PR TITLE
Migrate from flask._app_ctx_stack to app attributes for Flask 3 compat

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -384,22 +384,23 @@ dev = ["coverage", "pytest (>=7.4.4)"]
 
 [[package]]
 name = "flask"
-version = "2.3.3"
+version = "3.1.3"
 description = "A simple framework for building complex web applications."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "flask-2.3.3-py3-none-any.whl", hash = "sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b"},
-    {file = "flask-2.3.3.tar.gz", hash = "sha256:09c347a92aa7ff4a8e7f3206795f30d826654baf38b873d0744cd571ca609efc"},
+    {file = "flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c"},
+    {file = "flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb"},
 ]
 
 [package.dependencies]
-blinker = ">=1.6.2"
+blinker = ">=1.9.0"
 click = ">=8.1.3"
-itsdangerous = ">=2.1.2"
-Jinja2 = ">=3.1.2"
-Werkzeug = ">=2.3.7"
+itsdangerous = ">=2.2.0"
+jinja2 = ">=3.1.2"
+markupsafe = ">=2.1.1"
+werkzeug = ">=3.1.0"
 
 [package.extras]
 async = ["asgiref (>=3.2)"]
@@ -1071,18 +1072,18 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "werkzeug"
-version = "2.3.8"
+version = "3.1.8"
 description = "The comprehensive WSGI web application library."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "werkzeug-2.3.8-py3-none-any.whl", hash = "sha256:bba1f19f8ec89d4d607a3bd62f1904bd2e609472d93cd85e9d4e178f472c3748"},
-    {file = "werkzeug-2.3.8.tar.gz", hash = "sha256:554b257c74bbeb7a0d254160a4f8ffe185243f52a52035060b761ca62d977f03"},
+    {file = "werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50"},
+    {file = "werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44"},
 ]
 
 [package.dependencies]
-MarkupSafe = ">=2.1.1"
+markupsafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
@@ -1090,4 +1091,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "ce6f37291afa912c56e140a001ea2a0970c43063c3efdd38eff48a2916e31df3"
+content-hash = "37f69cdd5fa658047f101e4c08fe1e09c0819a9d336c075c7222363d8a8970f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "slack-export-viewer"
 version = "3.5.0"
 description = "Slack Export Archive Viewer"
-authors = ["hfaran <hamzafaran@outlook.com>"]
+authors = ["hfaran"]
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/hfaran/slack-export-viewer"
@@ -12,11 +12,11 @@ packages = [{include = "slackviewer"}]
 [tool.poetry.dependencies]
 python = ">=3.12"
 click = "*"
-Werkzeug = "<3.0.0"
-Flask = "<3.0.0"
+Werkzeug = ">=3.0.0"
+Flask = ">=3.0.0"
 markdown2 = "*"
 emoji = ">=2.0.0,<3.0"
-frozen-flask = ">=1.0.1,<2.0"
+frozen-flask = ">=1.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pypandoc = "*"

--- a/slackviewer/app.py
+++ b/slackviewer/app.py
@@ -15,11 +15,11 @@ def read_css_file(file_path):
 
 @app.route("/channel/<name>/")
 def channel_name(name):
-    messages = flask._app_ctx_stack.channels[name]
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys()) if flask._app_ctx_stack.groups else {}
-    dm_users = list(flask._app_ctx_stack.dm_users)
-    mpim_users = list(flask._app_ctx_stack.mpim_users)
+    messages = app.channels[name]
+    channels = list(app.channels.keys())
+    groups = list(app.groups.keys()) if app.groups else {}
+    dm_users = list(app.dm_users)
+    mpim_users = list(app.mpim_users)
 
     viewer_css_contents = read_css_file(os.path.join(app.static_folder, 'viewer.css')) if app.no_external_references else None
 
@@ -36,16 +36,16 @@ def channel_name(name):
 
 @app.route("/channel/<name>/attachments/<attachment>")
 def channel_name_attachment(name, attachment):
-    return flask.send_file(os.path.join(flask._app_ctx_stack.path, name, "attachments", attachment))
+    return flask.send_file(os.path.join(app.slack_path, name, "attachments", attachment))
 
 
 @app.route("/group/<name>/")
 def group_name(name):
-    messages = flask._app_ctx_stack.groups[name]
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys())
-    dm_users = list(flask._app_ctx_stack.dm_users)
-    mpim_users = list(flask._app_ctx_stack.mpim_users)
+    messages = app.groups[name]
+    channels = list(app.channels.keys())
+    groups = list(app.groups.keys())
+    dm_users = list(app.dm_users)
+    mpim_users = list(app.mpim_users)
 
     viewer_css_contents = read_css_file(os.path.join(app.static_folder, 'viewer.css')) if app.no_external_references else None
 
@@ -62,16 +62,16 @@ def group_name(name):
 
 @app.route("/group/<name>/attachments/<attachment>")
 def group_name_attachment(name, attachment):
-    return flask.send_file(os.path.join(flask._app_ctx_stack.path, name, "attachments", attachment))
+    return flask.send_file(os.path.join(app.slack_path, name, "attachments", attachment))
 
 
 @app.route("/dm/<id>/")
 def dm_id(id):
-    messages = flask._app_ctx_stack.dms[id]
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys())
-    dm_users = list(flask._app_ctx_stack.dm_users)
-    mpim_users = list(flask._app_ctx_stack.mpim_users)
+    messages = app.dms[id]
+    channels = list(app.channels.keys())
+    groups = list(app.groups.keys())
+    dm_users = list(app.dm_users)
+    mpim_users = list(app.mpim_users)
 
     viewer_css_contents = read_css_file(os.path.join(app.static_folder, 'viewer.css')) if app.no_external_references else None
 
@@ -88,16 +88,16 @@ def dm_id(id):
 
 @app.route("/dm/<name>/attachments/<attachment>")
 def dm_name_attachment(name, attachment):
-    return flask.send_file(os.path.join(flask._app_ctx_stack.path, name, "attachments", attachment))
+    return flask.send_file(os.path.join(app.slack_path, name, "attachments", attachment))
 
 
 @app.route("/mpim/<name>/")
 def mpim_name(name):
-    messages = flask._app_ctx_stack.mpims.get(name, list())
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys())
-    dm_users = list(flask._app_ctx_stack.dm_users)
-    mpim_users = list(flask._app_ctx_stack.mpim_users)
+    messages = app.mpims.get(name, list())
+    channels = list(app.channels.keys())
+    groups = list(app.groups.keys())
+    dm_users = list(app.dm_users)
+    mpim_users = list(app.mpim_users)
 
     viewer_css_contents = read_css_file(os.path.join(app.static_folder, 'viewer.css')) if app.no_external_references else None
 
@@ -114,15 +114,15 @@ def mpim_name(name):
 
 @app.route("/mpim/<name>/attachments/<attachment>")
 def mpim_name_attachment(name, attachment):
-    return flask.send_file(os.path.join(flask._app_ctx_stack.path, name, "attachments", attachment))
+    return flask.send_file(os.path.join(app.slack_path, name, "attachments", attachment))
 
 
 @app.route("/")
 def index():
-    channels = list(flask._app_ctx_stack.channels.keys())
-    groups = list(flask._app_ctx_stack.groups.keys())
-    dms = list(flask._app_ctx_stack.dms.keys())
-    mpims = list(flask._app_ctx_stack.mpims.keys())
+    channels = list(app.channels.keys())
+    groups = list(app.groups.keys())
+    dms = list(app.dms.keys())
+    mpims = list(app.mpims.keys())
     if channels:
         if "general" in channels:
             return channel_name("general")

--- a/slackviewer/main.py
+++ b/slackviewer/main.py
@@ -2,7 +2,6 @@ import webbrowser
 import os
 
 import click
-import flask
 
 from slackviewer.app import app
 from slackviewer.config import Config
@@ -20,26 +19,25 @@ def configure_app(app, config):
 
     reader = Reader(config)
 
-    top = flask._app_ctx_stack
-    top.path = reader.archive_path()
-    top.channels = reader.compile_channels(config.channels)
-    top.groups = reader.compile_groups()
-    top.dms = {}
-    top.dm_users = []
-    top.mpims = {}
-    top.mpim_users = []
+    app.slack_path = reader.archive_path()
+    app.channels = reader.compile_channels(config.channels)
+    app.groups = reader.compile_groups()
+    app.dms = {}
+    app.dm_users = []
+    app.mpims = {}
+    app.mpim_users = []
     if config.show_dms:
-        top.dms = reader.compile_dm_messages()
-        top.dm_users = reader.compile_dm_users()
-        top.mpims = reader.compile_mpim_messages()
-        top.mpim_users = reader.compile_mpim_users()
+        app.dms = reader.compile_dm_messages()
+        app.dm_users = reader.compile_dm_users()
+        app.mpims = reader.compile_mpim_messages()
+        app.mpim_users = reader.compile_mpim_users()
 
     reader.warn_not_found_to_hide_channels()
 
     # remove any empty channels & groups. DM's are needed for now
     # since the application loads the first
-    top.channels = {k: v for k, v in top.channels.items() if v}
-    top.groups = {k: v for k, v in top.groups.items() if v}
+    app.channels = {k: v for k, v in app.channels.items() if v}
+    app.groups = {k: v for k, v in app.groups.items() if v}
 
 
 @click.command()
@@ -126,7 +124,7 @@ def main(**kwargs):
         # This tells freezer about the channel URLs
         @freezer.register_generator
         def channel_name():
-            for channel in flask._app_ctx_stack.channels:
+            for channel in app.channels:
                 yield {"name": channel}
 
         freezer.freeze()


### PR DESCRIPTION
## Summary

- Replaces all usages of the removed private `flask._app_ctx_stack` API with direct attributes on the `app` object (`app.channels`, `app.groups`, `app.dms`, `app.dm_users`, `app.mpims`, `app.mpim_users`, `app.slack_path`)
- Lifts version caps: `Flask <3.0.0` → `>=3.0.0`, `Werkzeug <3.0.0` → `>=3.0.0`, `frozen-flask <2.0` upper bound removed
- Resolves to Flask 3.1.3 + Werkzeug 3.1.8, unblocking the Dependabot security fix in #240
- Removes unused `import flask` from `main.py`

## Test plan

- [x] `poetry lock && poetry install` resolves successfully
- [x] `pytest` passes
- [ ] Manual smoke test: `slack-export-viewer -z <archive.zip>` loads channels and DMs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)