### PR TITLE
Upgrade GitHub Actions to v4

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
## Summary

- `actions/checkout@v3` → `actions/checkout@v4`
- `actions/setup-python@v3` → `actions/setup-python@v4`

Both are backwards-compatible drops-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)