### PR TITLE
Make pyproject.toml the single source of truth for version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,4 +5,13 @@
 
 ## Build and Publish
 
-4) Ensure the deploy GitHub Action succeeds
+### Automated
+
+4) Ensure the deploy GitHub Action succeeds, or
+
+### Manual
+
+4) `git pull` locally
+5) `git clean -fdx dist` to clean anything already in the dist/ directory
+6) Run `python -m build` (in the correct environment) to create the package to upload
+7) Run `twine upload dist/*` to push to PyPI

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,10 @@
 
 ### Manual
 
-4) `git pull` locally
-5) `git clean -fdx dist` to clean anything already in the dist/ directory
-6) Run `python -m build` (in the correct environment) to create the package to upload
-7) Run `twine upload dist/*` to push to PyPI
+4) `git pull` locally to get the tagged release commit
+5) `poetry install` to sync the environment
+6) `git clean -fdx dist` to remove any stale build artifacts
+7) `poetry build` to produce the sdist and wheel under `dist/`
+8) `twine upload dist/*` to push to PyPI
+   - Requires a PyPI API token — either set `TWINE_PASSWORD=<token>` and `TWINE_USERNAME=__token__` in your environment, or configure `~/.pypirc`
+   - Alternatively, `poetry publish` can replace this step if you have a token configured via `poetry config pypi-token.pypi <token>`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,8 @@
 # Release
-1) Update `__version__` in `slackviewer/__init__.py` to the new version
-2) Commit this change as "Release 0.9.0" to master, as an example
-3) Create a release on GitHub with the new version (e.g., 0.9.0) targeting master
+1) Update `version` in `pyproject.toml` to the new version
+2) Commit this change as "Release 4.1.0" to master, as an example
+3) Create a release on GitHub with the new version (e.g., 4.1.0) targeting master
 
 ## Build and Publish
 
-### Automated
-
-4) Ensure the deploy Github Action succeeds, or
-
-### Manual
-
-4) `git pull` locally
-5) `git clean -fdx dist` to clean anything already in the dist/ directory
-6) Run  `python setup.py sdist` (in the correct environment) to create the package to upload
-7) Run `twine upload dist/*` to push to PyPI
+4) Ensure the deploy GitHub Action succeeds

--- a/slackviewer/__init__.py
+++ b/slackviewer/__init__.py
@@ -1,1 +1,6 @@
-__version__ = "4.0.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("slack-export-viewer")
+except PackageNotFoundError:
+    __version__ = "unknown"


### PR DESCRIPTION
## Summary

- `slackviewer/__init__.py` now derives `__version__` from installed package metadata via `importlib.metadata` (stdlib) instead of a hardcoded string that had to be kept in sync with `pyproject.toml`
- `pyproject.toml` is now the one place to update on each release
- `RELEASE.md` updated to reflect this (step 1 now says edit `pyproject.toml`) and the defunct `python setup.py sdist` manual step removed

## Test plan

- [x] `poetry run python -c "import slackviewer; print(slackviewer.__version__)"` prints `4.0.0`
- [x] `pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)